### PR TITLE
Match the default value of `use_threads` with pyarrow

### DIFF
--- a/jollyjack/jollyjack.cc
+++ b/jollyjack/jollyjack.cc
@@ -19,44 +19,46 @@ arrow::Status ReadColumn (int column_index
     , size_t stride1_size
     , const std::vector<int> &column_indices
     , const std::vector<int> &target_column_indices
-    )
+    ) noexcept
 {
+  std::string column_name;
   const auto num_rows = row_group_metadata->num_rows();
   const auto parquet_column = column_indices[column_index];
-  const auto column_reader = row_group_reader->Column(parquet_column);
-  const auto column_name = column_reader->descr()->name();
-
-  int target_column = column_index;
-  if (target_column_indices.size() > 0)
-    target_column = target_column_indices[column_index];
-
-#ifdef DEBUG
-      std::cerr
-          << " column_index:" << column_index
-          << " target_column:" << target_column
-          << " parquet_column:" << parquet_column
-          << " logical_type:" << column_reader->descr()->logical_type()->ToString()
-          << " physical_type:" << column_reader->descr()->physical_type()
-          << std::endl;
-#endif
-
-  int64_t values_read = 0;
-  char *base_ptr = (char *)buffer;
-  size_t target_offset = stride0_size * target_row + stride1_size * target_column;
-  size_t required_size = target_offset + num_rows * stride0_size;
-
-  if (buffer_size < required_size)
-  {
-      auto msg = std::string("Buffer overrun protection:")          
-        + " buffer_size:" + std::to_string(buffer_size) + " required size:" + std::to_string(required_size) 
-        + ", target_row:" + std::to_string(target_row) + " target_column:" + std::to_string(target_column)  
-        + ", stride0:" + std::to_string(stride0_size) + " stride1:" + std::to_string(stride1_size);
-
-      throw std::logic_error(msg);
-  }
-
+  
   try
   {
+    const auto column_reader = row_group_reader->Column(parquet_column);
+    column_name = column_reader->descr()->name();
+
+    int target_column = column_index;
+    if (target_column_indices.size() > 0)
+      target_column = target_column_indices[column_index];
+
+    #ifdef DEBUG
+        std::cerr
+            << " column_index:" << column_index
+            << " target_column:" << target_column
+            << " parquet_column:" << parquet_column
+            << " logical_type:" << column_reader->descr()->logical_type()->ToString()
+            << " physical_type:" << column_reader->descr()->physical_type()
+            << std::endl;
+    #endif
+
+    int64_t values_read = 0;
+    char *base_ptr = (char *)buffer;
+    size_t target_offset = stride0_size * target_row + stride1_size * target_column;
+    size_t required_size = target_offset + num_rows * stride0_size;
+
+    if (buffer_size < required_size)
+    {
+        auto msg = std::string("Buffer overrun protection:")          
+          + " buffer_size:" + std::to_string(buffer_size) + " required size:" + std::to_string(required_size) 
+          + ", target_row:" + std::to_string(target_row) + " target_column:" + std::to_string(target_column)  
+          + ", stride0:" + std::to_string(stride0_size) + " stride1:" + std::to_string(stride1_size);
+
+        return arrow::Status::Invalid(msg);
+    }
+
     switch (column_reader->descr()->physical_type())
     {
       case parquet::Type::DOUBLE:
@@ -64,7 +66,7 @@ arrow::Status ReadColumn (int column_index
         if (stride0_size != 8)
         {
           auto msg = std::string("Column[" + std::to_string(parquet_column) + "] ('"  + column_name + "') has DOUBLE data type, but the target value size is " + std::to_string(stride0_size) + "!");
-          throw std::logic_error(msg);
+          return arrow::Status::Invalid(msg);
         }
 
         int64_t rows_to_read = num_rows;
@@ -84,7 +86,7 @@ arrow::Status ReadColumn (int column_index
         if (stride0_size != 4)
         {
           auto msg = std::string("Column[" + std::to_string(parquet_column) + "] ('"  + column_name + "') has FLOAT data type, but the target value size is " + std::to_string(stride0_size) + "!");
-          throw std::logic_error(msg);
+          return arrow::Status::Invalid(msg);
         }
 
         int64_t rows_to_read = num_rows;
@@ -105,7 +107,7 @@ arrow::Status ReadColumn (int column_index
         {
           auto msg = std::string("Column[" + std::to_string(parquet_column) + "] ('"  + column_name + "') has FIXED_LEN_BYTE_ARRAY data type with size " + std::to_string(column_reader->descr()->type_length()) + 
             ", but the target value size is " + std::to_string(stride0_size) + "!");
-          throw std::logic_error(msg);
+          return arrow::Status::Invalid(msg);
         }
 
         const int64_t warp_size = 1024;
@@ -124,7 +126,7 @@ arrow::Status ReadColumn (int column_index
                 // TODO(marcink)  We could copy each FLB pointed value one by one instead of throwing an exception.
                 //                However, at the time of this implementation, non-contiguous memory is impossible, so that exception is not expected to occur anyway.
                 auto msg = std::string("Unexpected, FLBA memory is not contiguous when reading olumn:" + std::to_string(parquet_column) + " !");
-                throw std::logic_error(msg);
+                return arrow::Status::Invalid(msg);
               }
 
               memcpy(&base_ptr[target_offset + values_read * stride0_size], flba[0].ptr, tmp_values_read * stride0_size);
@@ -139,8 +141,14 @@ arrow::Status ReadColumn (int column_index
       default:
       {
         auto msg = std::string("Column[" + std::to_string(parquet_column) + "] ('"  + column_name + "') has unsupported data type: " + std::to_string(column_reader->descr()->physical_type()) + "!");
-        throw std::logic_error(msg);
+        return arrow::Status::Invalid(msg);
       }
+    }
+
+    if (values_read != num_rows)
+    {
+      auto msg = std::string("Column[" + std::to_string(parquet_column) + "] ('"  + column_name + "'): Expected to read ") + std::to_string(num_rows) + " values, but read only " + std::to_string(values_read) + "!";
+      return arrow::Status::Invalid(msg);
     }
   }
   catch(const parquet::ParquetException& e)
@@ -148,16 +156,10 @@ arrow::Status ReadColumn (int column_index
     if (e.what() == std::string("Unexpected end of stream"))
     {
       auto msg = std::string(e.what() + std::string(". Column[" + std::to_string(parquet_column) + "] ('"  + column_name + "') contains null values?"));
-      throw std::logic_error(msg);
+      return arrow::Status::Invalid(msg);
     }
 
-    throw;
-  }
-  
-  if (values_read != num_rows)
-  {
-    auto msg = std::string("Column[" + std::to_string(parquet_column) + "] ('"  + column_name + "'): Expected to read ") + std::to_string(num_rows) + " values, but read only " + std::to_string(values_read) + "!";
-    throw std::logic_error(msg);
+    return arrow::Status::Invalid(e.what());
   }
 
   return arrow::Status::OK();
@@ -244,7 +246,10 @@ void ReadIntoMemory (std::shared_ptr<arrow::io::RandomAccessFile> source
                 , column_indices
                 , target_column_indices);
               });
-    
+    if (result != arrow::Status::OK())
+    {
+      throw std::logic_error(result.message());
+    }
     target_row += num_rows;
   }
 

--- a/jollyjack/jollyjack.cc
+++ b/jollyjack/jollyjack.cc
@@ -250,6 +250,7 @@ void ReadIntoMemory (std::shared_ptr<arrow::io::RandomAccessFile> source
     {
       throw std::logic_error(result.message());
     }
+
     target_row += num_rows;
   }
 

--- a/jollyjack/jollyjack_cython.pyx
+++ b/jollyjack/jollyjack_cython.pyx
@@ -14,7 +14,7 @@ from libc.stdint cimport uint32_t
 from pyarrow._parquet cimport *
 from pyarrow.lib cimport (get_reader)
 
-cpdef void read_into_torch (object source, FileMetaData metadata, tensor, row_group_indices, column_indices = [], column_names = [], pre_buffer=False, use_threads=True, use_memory_map=False):
+cpdef void read_into_torch (object source, FileMetaData metadata, tensor, row_group_indices, column_indices = [], column_names = [], pre_buffer=False, use_threads=False, use_memory_map = False):
 
     import torch
 
@@ -31,7 +31,7 @@ cpdef void read_into_torch (object source, FileMetaData metadata, tensor, row_gr
 
     return
 
-cpdef void read_into_numpy (object source, FileMetaData metadata, cnp.ndarray np_array, row_group_indices, column_indices = [], column_names = [], pre_buffer=False, use_threads=True, use_memory_map=False):
+cpdef void read_into_numpy (object source, FileMetaData metadata, cnp.ndarray np_array, row_group_indices, column_indices = [], column_names = [], pre_buffer=False, use_threads = False, use_memory_map = False):
 
     cdef vector[int] crow_group_indices = row_group_indices
     cdef vector[int] ccolumn_indices = column_indices.keys() if isinstance(column_indices, dict) else column_indices

--- a/jollyjack/jollyjack_cython.pyx
+++ b/jollyjack/jollyjack_cython.pyx
@@ -14,7 +14,7 @@ from libc.stdint cimport uint32_t
 from pyarrow._parquet cimport *
 from pyarrow.lib cimport (get_reader)
 
-cpdef void read_into_torch (object source, FileMetaData metadata, tensor, row_group_indices, column_indices = [], column_names = [], pre_buffer=False, use_threads=True, use_memory_map=False):
+cpdef void read_into_torch (object source, FileMetaData metadata, tensor, row_group_indices, column_indices = [], column_names = [], pre_buffer = False, use_threads = True, use_memory_map = False):
 
     import torch
 
@@ -31,7 +31,7 @@ cpdef void read_into_torch (object source, FileMetaData metadata, tensor, row_gr
 
     return
 
-cpdef void read_into_numpy (object source, FileMetaData metadata, cnp.ndarray np_array, row_group_indices, column_indices = [], column_names = [], pre_buffer=False, use_threads=True, use_memory_map=False):
+cpdef void read_into_numpy (object source, FileMetaData metadata, cnp.ndarray np_array, row_group_indices, column_indices = [], column_names = [], pre_buffer = False, use_threads = True, use_memory_map = False):
 
     cdef vector[int] crow_group_indices = row_group_indices
     cdef vector[int] ccolumn_indices = column_indices.keys() if isinstance(column_indices, dict) else column_indices

--- a/jollyjack/jollyjack_cython.pyx
+++ b/jollyjack/jollyjack_cython.pyx
@@ -14,7 +14,7 @@ from libc.stdint cimport uint32_t
 from pyarrow._parquet cimport *
 from pyarrow.lib cimport (get_reader)
 
-cpdef void read_into_torch (object source, FileMetaData metadata, tensor, row_group_indices, column_indices = [], column_names = [], pre_buffer=False, use_threads=False, use_memory_map = False):
+cpdef void read_into_torch (object source, FileMetaData metadata, tensor, row_group_indices, column_indices = [], column_names = [], pre_buffer=False, use_threads=True, use_memory_map=False):
 
     import torch
 
@@ -31,7 +31,7 @@ cpdef void read_into_torch (object source, FileMetaData metadata, tensor, row_gr
 
     return
 
-cpdef void read_into_numpy (object source, FileMetaData metadata, cnp.ndarray np_array, row_group_indices, column_indices = [], column_names = [], pre_buffer=False, use_threads = False, use_memory_map = False):
+cpdef void read_into_numpy (object source, FileMetaData metadata, cnp.ndarray np_array, row_group_indices, column_indices = [], column_names = [], pre_buffer=False, use_threads=True, use_memory_map=False):
 
     cdef vector[int] crow_group_indices = row_group_indices
     cdef vector[int] ccolumn_indices = column_indices.keys() if isinstance(column_indices, dict) else column_indices

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "jollyjack"
-version = "0.9.4"
+version = "0.9.3"
 description = "Read parquet data directly into numpy array"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "jollyjack"
-version = "0.9.3"
+version = "0.9.4"
 description = "Read parquet data directly into numpy array"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/test/test_jollyjack.py
+++ b/test/test_jollyjack.py
@@ -9,7 +9,9 @@ import numpy as np
 import platform
 import os
 import itertools
+import torch
 from pyarrow import fs
+from functools import wraps
 
 chunk_size = 3
 n_row_groups = 2
@@ -30,149 +32,155 @@ def get_table(n_rows, n_columns, data_type = pa.float32()):
     # Create a PyArrow Table from the Arrays
     return pa.Table.from_arrays(pa_arrays, schema=schema)
 
+def for_each_parameter():
+    def decorator(test_func):
+        @wraps(test_func)
+        def wrapper(self: unittest.TestCase):
+            for pre_buffer, use_threads, use_memory_map in itertools.product ([False, True], [False, True], [False, True]):
+                with self.subTest((pre_buffer, use_threads, use_memory_map)):
+                    test_func(self, pre_buffer = pre_buffer, use_threads = use_threads, use_memory_map = use_memory_map)
+
+        return wrapper
+    return decorator
+
 class TestJollyJack(unittest.TestCase):
 
-    def test_read_entire_table(self):
-        
-        for pre_buffer, use_threads, use_memory_map in itertools.product ([False, True], [False, True], [False, True]):
-            with self.subTest((pre_buffer, use_threads, use_memory_map)):
-                with tempfile.TemporaryDirectory() as tmpdirname:
-                    path = os.path.join(tmpdirname, "my.parquet")
-                    table = get_table(n_rows, n_columns)
-                    pq.write_table(table, path, row_group_size=chunk_size, use_dictionary=False, write_statistics=False, store_schema=False)
+    @for_each_parameter()
+    def test_read_entire_table(self, pre_buffer, use_threads, use_memory_map):
 
-                    pr = pq.ParquetReader()
-                    pr.open(path)
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            path = os.path.join(tmpdirname, "my.parquet")
+            table = get_table(n_rows, n_columns)
+            pq.write_table(table, path, row_group_size=chunk_size, use_dictionary=False, write_statistics=False, store_schema=False)
 
-                    # Create an array of zeros
-                    np_array1 = np.zeros((n_rows, n_columns), dtype='f', order='F')
+            pr = pq.ParquetReader()
+            pr.open(path)
 
-                    row_begin = 0
-                    row_end = 0
+            # Create an array of zeros
+            np_array1 = np.zeros((n_rows, n_columns), dtype='f', order='F')
 
-                    for rg in range(n_row_groups):
-                        row_begin = row_end
-                        row_end = row_begin + pr.metadata.row_group(rg).num_rows
-                        subset_view = np_array1[row_begin:row_end, :] 
-                        jj.read_into_numpy (source = path
-                                            , metadata = None
-                                            , np_array = subset_view
-                                            , row_group_indices = [rg]
-                                            , column_indices = range(pr.metadata.num_columns)
-                                            , pre_buffer = pre_buffer
-                                            , use_threads = use_threads
-                                            , use_memory_map = use_memory_map)
+            row_begin = 0
+            row_end = 0
 
-                    expected_data = pr.read_all()
-                    self.assertTrue(np.array_equal(np_array1, expected_data))
+            for rg in range(n_row_groups):
+                row_begin = row_end
+                row_end = row_begin + pr.metadata.row_group(rg).num_rows
+                subset_view = np_array1[row_begin:row_end, :] 
+                jj.read_into_numpy (source = path
+                                    , metadata = None
+                                    , np_array = subset_view
+                                    , row_group_indices = [rg]
+                                    , column_indices = range(pr.metadata.num_columns)
+                                    , pre_buffer = pre_buffer
+                                    , use_threads = use_threads
+                                    , use_memory_map = use_memory_map)
 
-                    np_array2 = np.zeros((n_rows, n_columns), dtype='f', order='F')
-                    jj.read_into_numpy (source = path
-                                        , metadata = None
-                                        , np_array = np_array2
-                                        , row_group_indices = range(pr.metadata.num_row_groups)
-                                        , column_indices = range(pr.metadata.num_columns)
-                                        , pre_buffer = pre_buffer
-                                        , use_threads = use_threads
-                                        , use_memory_map = use_memory_map)
+            expected_data = pr.read_all()
+            self.assertTrue(np.array_equal(np_array1, expected_data))
 
-                    self.assertTrue(np.array_equal(np_array2, expected_data))
-                    pr.close()
+            np_array2 = np.zeros((n_rows, n_columns), dtype='f', order='F')
+            jj.read_into_numpy (source = path
+                                , metadata = None
+                                , np_array = np_array2
+                                , row_group_indices = range(pr.metadata.num_row_groups)
+                                , column_indices = range(pr.metadata.num_columns)
+                                , pre_buffer = pre_buffer
+                                , use_threads = use_threads
+                                , use_memory_map = use_memory_map)
 
-    def test_read_with_palletjack(self):
-        
-        for pre_buffer, use_threads, use_memory_map in itertools.product ([False, True], [False, True], [False, True]):
-            with self.subTest((pre_buffer, use_threads, use_memory_map)):
-                with tempfile.TemporaryDirectory() as tmpdirname:
-                    path = os.path.join(tmpdirname, "my.parquet")
-                    table = get_table(n_rows, n_columns)
-                    pq.write_table(table, path, row_group_size=chunk_size, use_dictionary=False, write_statistics=False, store_schema=False)
+            self.assertTrue(np.array_equal(np_array2, expected_data))
+            pr.close()
 
-                    index_path = path + '.index'
-                    pj.generate_metadata_index(path, index_path)
+    @for_each_parameter()
+    def test_read_with_palletjack(self, pre_buffer, use_threads, use_memory_map):
 
-                    # Create an array of zeros
-                    np_array = np.zeros((n_rows, n_columns), dtype='f', order='F')
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            path = os.path.join(tmpdirname, "my.parquet")
+            table = get_table(n_rows, n_columns)
+            pq.write_table(table, path, row_group_size=chunk_size, use_dictionary=False, write_statistics=False, store_schema=False)
 
-                    row_begin = 0
-                    row_end = 0
+            index_path = path + '.index'
+            pj.generate_metadata_index(path, index_path)
 
-                    for rg in range(n_row_groups):
-                        column_indices=list(range(n_columns))
-                        metadata = pj.read_metadata(index_path, row_groups=[rg], column_indices=column_indices)
+            # Create an array of zeros
+            np_array = np.zeros((n_rows, n_columns), dtype='f', order='F')
 
-                        row_begin = row_end
-                        row_end = row_begin + metadata.num_rows
-                        subset_view = np_array[row_begin:row_end, :] 
-                        jj.read_into_numpy (source = path
-                                            , metadata = metadata
-                                            , np_array = subset_view
-                                            , row_group_indices = [0]
-                                            , column_indices = column_indices
-                                            , pre_buffer = pre_buffer
-                                            , use_threads = use_threads
-                                            , use_memory_map = use_memory_map)
+            row_begin = 0
+            row_end = 0
 
-                    pr = pq.ParquetReader()
-                    pr.open(path)
-                    expected_data = pr.read_all()
-                    self.assertTrue(np.array_equal(np_array, expected_data))
-                    pr.close()
+            for rg in range(n_row_groups):
+                column_indices=list(range(n_columns))
+                metadata = pj.read_metadata(index_path, row_groups=[rg], column_indices=column_indices)
 
-    def test_read_nonzero_column_offset(self):
-        
-        for pre_buffer, use_threads, use_memory_map in itertools.product ([False, True], [False, True], [False, True]):
-            with self.subTest((pre_buffer, use_threads, use_memory_map)):
+                row_begin = row_end
+                row_end = row_begin + metadata.num_rows
+                subset_view = np_array[row_begin:row_end, :] 
+                jj.read_into_numpy (source = path
+                                    , metadata = metadata
+                                    , np_array = subset_view
+                                    , row_group_indices = [0]
+                                    , column_indices = column_indices
+                                    , pre_buffer = pre_buffer
+                                    , use_threads = use_threads
+                                    , use_memory_map = use_memory_map)
+
+            pr = pq.ParquetReader()
+            pr.open(path)
+            expected_data = pr.read_all()
+            self.assertTrue(np.array_equal(np_array, expected_data))
+            pr.close()
+
+    @for_each_parameter()
+    def test_read_nonzero_column_offset(self, pre_buffer, use_threads, use_memory_map):
+
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            path = os.path.join(tmpdirname, "my.parquet")
+            table = get_table(n_rows = chunk_size, n_columns = n_columns)
+            pq.write_table(table, path, row_group_size=chunk_size, use_dictionary=False, write_statistics=False, store_schema=False)
+
+            # Create an array of zeros
+            cols = 2
+            offset = n_columns - cols
+            np_array = np.zeros((chunk_size, cols), dtype='f', order='F')
+
+            jj.read_into_numpy (source = path
+                                , metadata = None
+                                , np_array = np_array
+                                , row_group_indices = [0]
+                                , column_indices = range(offset, offset + cols)
+                                , pre_buffer = pre_buffer
+                                , use_threads = use_threads
+                                , use_memory_map = use_memory_map)
+
+            pr = pq.ParquetReader()
+            pr.open(path)
+            expected_data = pr.read_all(column_indices = range(offset, offset + cols))
+            self.assertTrue(np.array_equal(np_array, expected_data))
+            pr.close()
+
+    @for_each_parameter()
+    def test_read_unsupported_column_types(self, pre_buffer, use_threads, use_memory_map):
+
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            path = os.path.join(tmpdirname, "my.parquet")
+            table = get_table(n_rows = chunk_size, n_columns = n_columns, data_type = pa.bool_())
+            pq.write_table(table, path, row_group_size=chunk_size, use_dictionary=False, write_statistics=False, store_schema=False)
+
+            # Create an array of zerosx
+            np_array = np.zeros((chunk_size, n_columns), dtype='f', order='F')
+
+            with self.assertRaises(RuntimeError) as context:
+                jj.read_into_numpy (source = path
+                                    , metadata = None
+                                    , np_array = np_array
+                                    , row_group_indices = [0]
+                                    , column_indices = range(n_columns)
+                                    , pre_buffer = pre_buffer
+                                    , use_threads = use_threads
+                                    , use_memory_map = use_memory_map)
+
+        self.assertTrue(f"Column[0] ('column_0') has unsupported data type: 0!" in str(context.exception), context.exception)
                 
-                with tempfile.TemporaryDirectory() as tmpdirname:
-                    path = os.path.join(tmpdirname, "my.parquet")
-                    table = get_table(n_rows = chunk_size, n_columns = n_columns)
-                    pq.write_table(table, path, row_group_size=chunk_size, use_dictionary=False, write_statistics=False, store_schema=False)
-
-                    # Create an array of zeros
-                    cols = 2
-                    offset = n_columns - cols
-                    np_array = np.zeros((chunk_size, cols), dtype='f', order='F')
-
-                    jj.read_into_numpy (source = path
-                                        , metadata = None
-                                        , np_array = np_array
-                                        , row_group_indices = [0]
-                                        , column_indices = range(offset, offset + cols)
-                                        , pre_buffer = pre_buffer
-                                        , use_threads = use_threads
-                                        , use_memory_map = use_memory_map)
-
-                    pr = pq.ParquetReader()
-                    pr.open(path)
-                    expected_data = pr.read_all(column_indices = range(offset, offset + cols))
-                    self.assertTrue(np.array_equal(np_array, expected_data))
-                    pr.close()
-
-    def test_read_unsupported_column_types(self):
-        
-        for pre_buffer, use_threads, use_memory_map in itertools.product ([False, True], [False, True], [False, True]):
-            with self.subTest((pre_buffer, use_threads, use_memory_map)):
-                with tempfile.TemporaryDirectory() as tmpdirname:
-                    path = os.path.join(tmpdirname, "my.parquet")
-                    table = get_table(n_rows = chunk_size, n_columns = n_columns, data_type = pa.bool_())
-                    pq.write_table(table, path, row_group_size=chunk_size, use_dictionary=False, write_statistics=False, store_schema=False)
-
-                    # Create an array of zerosx
-                    np_array = np.zeros((chunk_size, n_columns), dtype='f', order='F')
-
-                    with self.assertRaises(RuntimeError) as context:
-                        jj.read_into_numpy (source = path
-                                            , metadata = None
-                                            , np_array = np_array
-                                            , row_group_indices = [0]
-                                            , column_indices = range(n_columns)
-                                            , pre_buffer = pre_buffer
-                                            , use_threads = use_threads
-                                            , use_memory_map = use_memory_map)
-
-            self.assertTrue(f"Column[0] ('column_0') has unsupported data type: 0!" in str(context.exception), context.exception)
-                        
     def test_read_dtype_numpy(self):
         
         for pre_buffer in [False, True]:
@@ -270,158 +278,149 @@ class TestJollyJack(unittest.TestCase):
                         self.assertTrue(np.array_equal(tensor.numpy(), expected_data), f"{tensor.numpy()}\n{expected_data}")
                         pr.close()
 
-    def test_read_numpy_column_names(self):
+    @for_each_parameter()
+    def test_read_numpy_column_names(self, pre_buffer, use_threads, use_memory_map):
 
-        for pre_buffer, use_threads, use_memory_map in itertools.product ([False, True], [False, True], [False, True]):
-            with self.subTest((pre_buffer, use_threads, use_memory_map)):
-                with tempfile.TemporaryDirectory() as tmpdirname:
-                    path = os.path.join(tmpdirname, "my.parquet")
-                    table = get_table(n_rows = n_rows, n_columns = n_columns, data_type = pa.float32())
-                    pq.write_table(table, path, row_group_size=chunk_size, use_dictionary=False, write_statistics=False, store_schema=False)
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            path = os.path.join(tmpdirname, "my.parquet")
+            table = get_table(n_rows = n_rows, n_columns = n_columns, data_type = pa.float32())
+            pq.write_table(table, path, row_group_size=chunk_size, use_dictionary=False, write_statistics=False, store_schema=False)
 
-                    # Create an empty array
-                    np_array = np.zeros((n_rows, n_columns), dtype=pa.float32().to_pandas_dtype(), order='F')
+            # Create an empty array
+            np_array = np.zeros((n_rows, n_columns), dtype=pa.float32().to_pandas_dtype(), order='F')
 
-                    jj.read_into_numpy (source = path
-                                        , metadata = None
-                                        , np_array = np_array
-                                        , row_group_indices = range(n_row_groups)
-                                        , column_names = [f'column_{i}' for i in range(n_columns)]
-                                        , pre_buffer = pre_buffer
-                                        , use_threads = use_threads
-                                        , use_memory_map = use_memory_map)
+            jj.read_into_numpy (source = path
+                                , metadata = None
+                                , np_array = np_array
+                                , row_group_indices = range(n_row_groups)
+                                , column_names = [f'column_{i}' for i in range(n_columns)]
+                                , pre_buffer = pre_buffer
+                                , use_threads = use_threads
+                                , use_memory_map = use_memory_map)
 
-                    pr = pq.ParquetReader()
-                    pr.open(path)
-                    expected_data = pr.read_all().to_pandas().to_numpy()
-                    self.assertTrue(np.array_equal(np_array, expected_data), f"{np_array}\n{expected_data}")
-                    pr.close()
+            pr = pq.ParquetReader()
+            pr.open(path)
+            expected_data = pr.read_all().to_pandas().to_numpy()
+            self.assertTrue(np.array_equal(np_array, expected_data), f"{np_array}\n{expected_data}")
+            pr.close()
 
-    def test_read_torch_column_names(self):
+    @for_each_parameter()
+    def test_read_torch_column_names(self, pre_buffer, use_threads, use_memory_map):
 
-        import torch
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            path = os.path.join(tmpdirname, "my.parquet")
+            table = get_table(n_rows = n_rows, n_columns = n_columns, data_type = pa.float32())
+            pq.write_table(table, path, row_group_size=chunk_size, use_dictionary=False, write_statistics=False, store_schema=False)
 
-        for pre_buffer, use_threads, use_memory_map in itertools.product ([False, True], [False, True], [False, True]):
-            with self.subTest((pre_buffer, use_threads, use_memory_map)):
-                with tempfile.TemporaryDirectory() as tmpdirname:
-                    path = os.path.join(tmpdirname, "my.parquet")
-                    table = get_table(n_rows = n_rows, n_columns = n_columns, data_type = pa.float32())
-                    pq.write_table(table, path, row_group_size=chunk_size, use_dictionary=False, write_statistics=False, store_schema=False)
+            # Create an empty array
+            tensor = torch.zeros(n_columns, n_rows, dtype = torch.float32).transpose(0, 1)
 
-                    # Create an empty array
-                    tensor = torch.zeros(n_columns, n_rows, dtype = torch.float32).transpose(0, 1)
+            jj.read_into_torch (source = path
+                                , metadata = None
+                                , tensor = tensor
+                                , row_group_indices = range(n_row_groups)
+                                , column_names = [f'column_{i}' for i in range(n_columns)]
+                                , pre_buffer = pre_buffer
+                                , use_threads = use_threads
+                                , use_memory_map = use_memory_map)
 
-                    jj.read_into_torch (source = path
-                                        , metadata = None
-                                        , tensor = tensor
-                                        , row_group_indices = range(n_row_groups)
-                                        , column_names = [f'column_{i}' for i in range(n_columns)]
-                                        , pre_buffer = pre_buffer
-                                        , use_threads = use_threads
-                                        , use_memory_map = use_memory_map)
+            pr = pq.ParquetReader()
+            pr.open(path)
+            expected_data = pr.read_all().to_pandas().to_numpy()
+            self.assertTrue(np.array_equal(tensor.numpy(), expected_data), f"{tensor.numpy()}\n{expected_data}")
+            pr.close()
 
-                    pr = pq.ParquetReader()
-                    pr.open(path)
-                    expected_data = pr.read_all().to_pandas().to_numpy()
-                    self.assertTrue(np.array_equal(tensor.numpy(), expected_data), f"{tensor.numpy()}\n{expected_data}")
-                    pr.close()
+    @for_each_parameter()
+    def test_read_invalid_column(self, pre_buffer, use_threads, use_memory_map):
 
-    def test_read_invalid_column(self):
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            path = os.path.join(tmpdirname, "my.parquet")
+            table = get_table(n_rows = n_rows, n_columns = n_columns, data_type = pa.float32())
+            pq.write_table(table, path, row_group_size=chunk_size, use_dictionary=False, write_statistics=False, store_schema=False)
 
-        for pre_buffer, use_threads, use_memory_map in itertools.product ([False, True], [False, True], [False, True]):
-            with self.subTest((pre_buffer, use_threads, use_memory_map)):
+            pr = pq.ParquetReader()
+            pr.open(path)
+
+            # Create an empty array
+            np_array = np.zeros((n_rows, n_columns), dtype=pa.float32().to_pandas_dtype(), order='F')
+
+            with self.assertRaises(RuntimeError) as context:
+                jj.read_into_numpy (source = path
+                                    , metadata = None
+                                    , np_array = np_array
+                                    , row_group_indices = range(n_row_groups)
+                                    , column_names = [f'foo_bar_{i}' for i in range(n_columns)]
+                                    , pre_buffer = pre_buffer
+                                    , use_threads = use_threads
+                                    , use_memory_map = use_memory_map)
+
+            self.assertTrue(f"Column 'foo_bar_0' was not found!" in str(context.exception), context.exception)
                 
-                with tempfile.TemporaryDirectory() as tmpdirname:
-                    path = os.path.join(tmpdirname, "my.parquet")
-                    table = get_table(n_rows = n_rows, n_columns = n_columns, data_type = pa.float32())
-                    pq.write_table(table, path, row_group_size=chunk_size, use_dictionary=False, write_statistics=False, store_schema=False)
+            with self.assertRaises(RuntimeError) as context:
+                jj.read_into_numpy (source = path
+                                    , metadata = None
+                                    , np_array = np_array
+                                    , row_group_indices = range(n_row_groups)
+                                    , column_indices = [i + 1 for i in range(n_columns)]
+                                    , pre_buffer = pre_buffer
+                                    , use_threads = use_threads
+                                    , use_memory_map = use_memory_map)
 
-                    pr = pq.ParquetReader()
-                    pr.open(path)
+            self.assertTrue(f"Trying to read column index {n_columns} but row group metadata has only {n_columns} columns" in str(context.exception), context.exception)
+            pr.close()
 
-                    # Create an empty array
-                    np_array = np.zeros((n_rows, n_columns), dtype=pa.float32().to_pandas_dtype(), order='F')
-
-                    with self.assertRaises(RuntimeError) as context:
-                        jj.read_into_numpy (source = path
-                                            , metadata = None
-                                            , np_array = np_array
-                                            , row_group_indices = range(n_row_groups)
-                                            , column_names = [f'foo_bar_{i}' for i in range(n_columns)]
-                                            , pre_buffer = pre_buffer
-                                            , use_threads = use_threads
-                                            , use_memory_map = use_memory_map)
-
-                    self.assertTrue(f"Column 'foo_bar_0' was not found!" in str(context.exception), context.exception)
-                        
-                    with self.assertRaises(RuntimeError) as context:
-                        jj.read_into_numpy (source = path
-                                            , metadata = None
-                                            , np_array = np_array
-                                            , row_group_indices = range(n_row_groups)
-                                            , column_indices = [i + 1 for i in range(n_columns)]
-                                            , pre_buffer = pre_buffer
-                                            , use_threads = use_threads
-                                            , use_memory_map = use_memory_map)
-
-                    self.assertTrue(f"Trying to read column index {n_columns} but row group metadata has only {n_columns} columns" in str(context.exception), context.exception)
-                    pr.close()
-
-    def test_read_filesystem(self):
+    @for_each_parameter()
+    def test_read_filesystem(self, pre_buffer, use_threads, use_memory_map):
                 
         with tempfile.TemporaryDirectory() as tmpdirname:
             path = os.path.join(tmpdirname, "my.parquet")
             table = get_table(n_rows = n_rows, n_columns = n_columns, data_type = pa.float32())
             pq.write_table(table, path, row_group_size=chunk_size, use_dictionary=False, write_statistics=False, store_schema=False)
 
-            for pre_buffer, use_threads, use_memory_map in itertools.product ([False, True], [False, True], [False, True]):
-                with self.subTest((pre_buffer, use_threads, use_memory_map)):
+            # Create an empty array
+            np_array = np.zeros((n_rows, n_columns), dtype=pa.float32().to_pandas_dtype(), order='F')
 
-                    # Create an empty array
-                    np_array = np.zeros((n_rows, n_columns), dtype=pa.float32().to_pandas_dtype(), order='F')
+            with fs.LocalFileSystem().open_input_file(path) as f:
+                jj.read_into_numpy (source = f
+                                    , metadata = None
+                                    , np_array = np_array
+                                    , row_group_indices = range(n_row_groups)
+                                    , column_names = [f'column_{i}' for i in range(n_columns)]
+                                    , pre_buffer = pre_buffer
+                                    , use_threads = use_threads
+                                    , use_memory_map = use_memory_map)
 
-                    with fs.LocalFileSystem().open_input_file(path) as f:
-                        jj.read_into_numpy (source = f
-                                            , metadata = None
-                                            , np_array = np_array
-                                            , row_group_indices = range(n_row_groups)
-                                            , column_names = [f'column_{i}' for i in range(n_columns)]
-                                            , pre_buffer = pre_buffer
-                                            , use_threads = use_threads
-                                            , use_memory_map = use_memory_map)
+            pr = pq.ParquetReader()
+            pr.open(path)
+            expected_data = pr.read_all().to_pandas().to_numpy()
+            self.assertTrue(np.array_equal(np_array, expected_data), f"{np_array}\n{expected_data}")
+            pr.close()
 
-                    pr = pq.ParquetReader()
-                    pr.open(path)
-                    expected_data = pr.read_all().to_pandas().to_numpy()
-                    self.assertTrue(np.array_equal(np_array, expected_data), f"{np_array}\n{expected_data}")
-                    pr.close()
+    @for_each_parameter()
+    def test_read_invalid_row_group(self, pre_buffer, use_threads, use_memory_map):
 
-    def test_read_invalid_row_group(self):
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            path = os.path.join(tmpdirname, "my.parquet")
+            table = get_table(n_rows = n_rows, n_columns = n_columns, data_type = pa.float32())
+            pq.write_table(table, path, row_group_size=chunk_size, use_dictionary=False, write_statistics=False, store_schema=False)
 
-        for pre_buffer, use_threads, use_memory_map in itertools.product ([False, True], [False, True], [False, True]):
-            with self.subTest((pre_buffer, use_threads, use_memory_map)):
-                
-                with tempfile.TemporaryDirectory() as tmpdirname:
-                    path = os.path.join(tmpdirname, "my.parquet")
-                    table = get_table(n_rows = n_rows, n_columns = n_columns, data_type = pa.float32())
-                    pq.write_table(table, path, row_group_size=chunk_size, use_dictionary=False, write_statistics=False, store_schema=False)
+            # Create an empty array
+            np_array = np.zeros((n_rows, n_columns), dtype=pa.float32().to_pandas_dtype(), order='F')
 
-                    # Create an empty array
-                    np_array = np.zeros((n_rows, n_columns), dtype=pa.float32().to_pandas_dtype(), order='F')
+            with self.assertRaises(RuntimeError) as context:
+                jj.read_into_numpy (source = path
+                                    , metadata = None
+                                    , np_array = np_array
+                                    , row_group_indices = [n_row_groups]
+                                    , column_names = [f'column_{i}' for i in range(n_columns)]
+                                    , pre_buffer = pre_buffer
+                                    , use_threads = use_threads
+                                    , use_memory_map = use_memory_map)
+    
+        self.assertTrue(f"Trying to read row group {n_row_groups} but file only has {n_row_groups} row groups" in str(context.exception), context.exception)
 
-                    with self.assertRaises(RuntimeError) as context:
-                        jj.read_into_numpy (source = path
-                                            , metadata = None
-                                            , np_array = np_array
-                                            , row_group_indices = [n_row_groups]
-                                            , column_names = [f'column_{i}' for i in range(n_columns)]
-                                            , pre_buffer = pre_buffer
-                                            , use_threads = use_threads
-                                            , use_memory_map = use_memory_map)
-            
-            self.assertTrue(f"Trying to read row group {n_row_groups} but file only has {n_row_groups} row groups" in str(context.exception), context.exception)
-
-    def test_read_data_with_nulls(self):
+    @for_each_parameter()
+    def test_read_data_with_nulls(self, pre_buffer, use_threads, use_memory_map):
 
         with tempfile.TemporaryDirectory() as tmpdirname:
             path = os.path.join(tmpdirname, "my.parquet")
@@ -432,130 +431,121 @@ class TestJollyJack(unittest.TestCase):
 
             pq.write_table(table, path, row_group_size=chunk_size, use_dictionary=False, write_statistics=False, store_schema=False)
 
-            for pre_buffer, use_threads, use_memory_map in itertools.product ([False, True], [False, True], [False, True]):
-                with self.subTest((pre_buffer, use_threads, use_memory_map)):
+            # Create an empty array
+            np_array = np.zeros((n_rows, n_columns), dtype=pa.float32().to_pandas_dtype(), order='F')
 
-                    # Create an empty array
-                    np_array = np.zeros((n_rows, n_columns), dtype=pa.float32().to_pandas_dtype(), order='F')
+            with self.assertRaises(RuntimeError) as context:
+                jj.read_into_numpy (source = path
+                                    , metadata = None
+                                    , np_array = np_array
+                                    , row_group_indices = range(n_row_groups)
+                                    , column_names = [f'column_{i}' for i in range(n_columns)]
+                                    , pre_buffer = pre_buffer
+                                    , use_threads = use_threads
+                                    , use_memory_map = use_memory_map)
 
-                    with self.assertRaises(RuntimeError) as context:
-                        jj.read_into_numpy (source = path
-                                            , metadata = None
-                                            , np_array = np_array
-                                            , row_group_indices = range(n_row_groups)
-                                            , column_names = [f'column_{i}' for i in range(n_columns)]
-                                            , pre_buffer = pre_buffer
-                                            , use_threads = use_threads
-                                            , use_memory_map = use_memory_map)
+            self.assertTrue(f"Unexpected end of stream. Column[0] ('column_0') contains null values?" in str(context.exception), context.exception)
 
-                    self.assertTrue(f"Unexpected end of stream. Column[0] ('column_0') contains null values?" in str(context.exception), context.exception)
-
-    def test_read_not_enough_rows(self):
+    @for_each_parameter()
+    def test_read_not_enough_rows(self, pre_buffer, use_threads, use_memory_map):
 
         with tempfile.TemporaryDirectory() as tmpdirname:
             path = os.path.join(tmpdirname, "my.parquet")
             table = get_table(n_rows = n_rows, n_columns = n_columns, data_type = pa.float32())
             pq.write_table(table, path, row_group_size=chunk_size, use_dictionary=False, write_statistics=False, store_schema=False)
 
-            for pre_buffer, use_threads, use_memory_map in itertools.product ([False, True], [False, True], [False, True]):
-                with self.subTest((pre_buffer, use_threads, use_memory_map)):
+            # Create an empty array
+            np_array = np.zeros((n_rows + 1, n_columns), dtype=pa.float32().to_pandas_dtype(), order='F')
 
-                    # Create an empty array
-                    np_array = np.zeros((n_rows + 1, n_columns), dtype=pa.float32().to_pandas_dtype(), order='F')
+            with self.assertRaises(RuntimeError) as context:
+                jj.read_into_numpy (source = path
+                                    , metadata = None
+                                    , np_array = np_array
+                                    , row_group_indices = range(n_row_groups)
+                                    , column_names = [f'column_{i}' for i in range(n_columns)]
+                                    , pre_buffer = pre_buffer
+                                    , use_threads = use_threads
+                                    , use_memory_map = use_memory_map)
 
-                    with self.assertRaises(RuntimeError) as context:
-                        jj.read_into_numpy (source = path
-                                            , metadata = None
-                                            , np_array = np_array
-                                            , row_group_indices = range(n_row_groups)
-                                            , column_names = [f'column_{i}' for i in range(n_columns)]
-                                            , pre_buffer = pre_buffer
-                                            , use_threads = use_threads
-                                            , use_memory_map = use_memory_map)
+            self.assertTrue(f"Expected to read {n_rows + 1} rows, but read only {n_rows}!" in str(context.exception), context.exception)
 
-                    self.assertTrue(f"Expected to read {n_rows + 1} rows, but read only {n_rows}!" in str(context.exception), context.exception)
-
-    def test_read_numpy_column_names_mapping(self):
+    @for_each_parameter()
+    def test_read_numpy_column_names_mapping(self, pre_buffer, use_threads, use_memory_map):
 
         with tempfile.TemporaryDirectory() as tmpdirname:
             path = os.path.join(tmpdirname, "my.parquet")
             table = get_table(n_rows = n_rows, n_columns = n_columns, data_type = pa.float32())
             pq.write_table(table, path, row_group_size=chunk_size, use_dictionary=False, write_statistics=False, store_schema=False)
 
-            for pre_buffer, use_threads, use_memory_map in itertools.product ([False, True], [False, True], [False, True]):
-                with self.subTest((pre_buffer, use_threads, use_memory_map)):
-
-                    # Create an empty array
-                    np_array = np.zeros((n_rows, n_columns), dtype=pa.float32().to_pandas_dtype(), order='F')
-                    jj.read_into_numpy (source = path
-                                        , metadata = None
-                                        , np_array = np_array
-                                        , row_group_indices = range(n_row_groups)
-                                        , column_names = {f'column_{i}':n_columns - i - 1 for i in range(n_columns)}
-                                        , pre_buffer = pre_buffer
-                                        , use_threads = use_threads
-                                        , use_memory_map = use_memory_map)
-                
-                    pr = pq.ParquetReader()
-                    pr.open(path)
-                    expected_data = pr.read_all().to_pandas().to_numpy()
-                    reversed_expected_data = expected_data[:, ::-1]
-                    self.assertTrue(np.array_equal(np_array, reversed_expected_data), f"\n{np_array}\n\n{reversed_expected_data}")
-                    
-                    np_array = np.zeros((n_rows, n_columns), dtype=pa.float32().to_pandas_dtype(), order='F')
-                    for c in range(n_columns):
-                        jj.read_into_numpy (source = path
-                                            , metadata = None
-                                            , np_array = np_array
-                                            , row_group_indices = range(n_row_groups)
-                                            , column_names = {f'column_{c}':n_columns - c - 1}
-                                            , pre_buffer = pre_buffer
-                                            , use_threads = use_threads
-                                            , use_memory_map = use_memory_map)
-
-                    self.assertTrue(np.array_equal(np_array, reversed_expected_data), f"\n{np_array}\n\n{reversed_expected_data}")
-                    pr.close()
+            # Create an empty array
+            np_array = np.zeros((n_rows, n_columns), dtype=pa.float32().to_pandas_dtype(), order='F')
+            jj.read_into_numpy (source = path
+                                , metadata = None
+                                , np_array = np_array
+                                , row_group_indices = range(n_row_groups)
+                                , column_names = {f'column_{i}':n_columns - i - 1 for i in range(n_columns)}
+                                , pre_buffer = pre_buffer
+                                , use_threads = use_threads
+                                , use_memory_map = use_memory_map)
+        
+            pr = pq.ParquetReader()
+            pr.open(path)
+            expected_data = pr.read_all().to_pandas().to_numpy()
+            reversed_expected_data = expected_data[:, ::-1]
+            self.assertTrue(np.array_equal(np_array, reversed_expected_data), f"\n{np_array}\n\n{reversed_expected_data}")
             
-    def test_read_numpy_column_indices_mapping(self):
+            np_array = np.zeros((n_rows, n_columns), dtype=pa.float32().to_pandas_dtype(), order='F')
+            for c in range(n_columns):
+                jj.read_into_numpy (source = path
+                                    , metadata = None
+                                    , np_array = np_array
+                                    , row_group_indices = range(n_row_groups)
+                                    , column_names = {f'column_{c}':n_columns - c - 1}
+                                    , pre_buffer = pre_buffer
+                                    , use_threads = use_threads
+                                    , use_memory_map = use_memory_map)
+
+            self.assertTrue(np.array_equal(np_array, reversed_expected_data), f"\n{np_array}\n\n{reversed_expected_data}")
+            pr.close()
+
+    @for_each_parameter()
+    def test_read_numpy_column_indices_mapping(self, pre_buffer, use_threads, use_memory_map):
 
         with tempfile.TemporaryDirectory() as tmpdirname:
             path = os.path.join(tmpdirname, "my.parquet")
             table = get_table(n_rows = n_rows, n_columns = n_columns, data_type = pa.float32())
             pq.write_table(table, path, row_group_size=chunk_size, use_dictionary=False, write_statistics=False, store_schema=False)
+  
+            # Create an empty array
+            np_array = np.zeros((n_rows, n_columns), dtype=pa.float32().to_pandas_dtype(), order='F')
+            jj.read_into_numpy (source = path
+                                , metadata = None
+                                , np_array = np_array
+                                , row_group_indices = range(n_row_groups)
+                                , column_indices = {i:n_columns - i - 1 for i in range(n_columns)}
+                                , pre_buffer = pre_buffer
+                                , use_threads = use_threads
+                                , use_memory_map = use_memory_map)
 
-            for pre_buffer, use_threads, use_memory_map in itertools.product ([False, True], [False, True], [False, True]):
-                with self.subTest((pre_buffer, use_threads, use_memory_map)):
+            pr = pq.ParquetReader()
+            pr.open(path)
+            expected_data = pr.read_all().to_pandas().to_numpy()
+            reversed_expected_data = expected_data[:, ::-1]
+            self.assertTrue(np.array_equal(np_array, reversed_expected_data), f"\n{np_array}\n\n{reversed_expected_data}")
+            
+            np_array = np.zeros((n_rows, n_columns), dtype=pa.float32().to_pandas_dtype(), order='F')
+            for c in range(n_columns):
+                jj.read_into_numpy (source = path
+                                    , metadata = None
+                                    , np_array = np_array
+                                    , row_group_indices = range(n_row_groups)
+                                    , column_indices = {c : n_columns - c - 1}
+                                    , pre_buffer = pre_buffer
+                                    , use_threads = use_threads
+                                    , use_memory_map = use_memory_map)
 
-                    # Create an empty array
-                    np_array = np.zeros((n_rows, n_columns), dtype=pa.float32().to_pandas_dtype(), order='F')
-                    jj.read_into_numpy (source = path
-                                        , metadata = None
-                                        , np_array = np_array
-                                        , row_group_indices = range(n_row_groups)
-                                        , column_indices = {i:n_columns - i - 1 for i in range(n_columns)}
-                                        , pre_buffer = pre_buffer
-                                        , use_threads = use_threads
-                                        , use_memory_map = use_memory_map)
-
-                    pr = pq.ParquetReader()
-                    pr.open(path)
-                    expected_data = pr.read_all().to_pandas().to_numpy()
-                    reversed_expected_data = expected_data[:, ::-1]
-                    self.assertTrue(np.array_equal(np_array, reversed_expected_data), f"\n{np_array}\n\n{reversed_expected_data}")
-                    
-                    np_array = np.zeros((n_rows, n_columns), dtype=pa.float32().to_pandas_dtype(), order='F')
-                    for c in range(n_columns):
-                        jj.read_into_numpy (source = path
-                                            , metadata = None
-                                            , np_array = np_array
-                                            , row_group_indices = range(n_row_groups)
-                                            , column_indices = {c : n_columns - c - 1}
-                                            , pre_buffer = pre_buffer
-                                            , use_threads = use_threads
-                                            , use_memory_map = use_memory_map)
-
-                    self.assertTrue(np.array_equal(np_array, reversed_expected_data), f"\n{np_array}\n\n{reversed_expected_data}")
-                    pr.close()
+            self.assertTrue(np.array_equal(np_array, reversed_expected_data), f"\n{np_array}\n\n{reversed_expected_data}")
+            pr.close()
             
     def test_read_large_array(self):
 

--- a/test/test_jollyjack.py
+++ b/test/test_jollyjack.py
@@ -8,6 +8,7 @@ import pyarrow as pa
 import numpy as np
 import platform
 import os
+import itertools
 from pyarrow import fs
 
 chunk_size = 3
@@ -32,115 +33,143 @@ def get_table(n_rows, n_columns, data_type = pa.float32()):
 class TestJollyJack(unittest.TestCase):
 
     def test_read_entire_table(self):
-        with tempfile.TemporaryDirectory() as tmpdirname:
-            path = os.path.join(tmpdirname, "my.parquet")
-            table = get_table(n_rows, n_columns)
-            pq.write_table(table, path, row_group_size=chunk_size, use_dictionary=False, write_statistics=False, store_schema=False)
+        
+        for pre_buffer, use_threads, use_memory_map in itertools.product ([False, True], [False, True], [False, True]):
+            with self.subTest((pre_buffer, use_threads, use_memory_map)):
+                with tempfile.TemporaryDirectory() as tmpdirname:
+                    path = os.path.join(tmpdirname, "my.parquet")
+                    table = get_table(n_rows, n_columns)
+                    pq.write_table(table, path, row_group_size=chunk_size, use_dictionary=False, write_statistics=False, store_schema=False)
 
-            pr = pq.ParquetReader()
-            pr.open(path)
+                    pr = pq.ParquetReader()
+                    pr.open(path)
 
-            # Create an array of zeros
-            np_array1 = np.zeros((n_rows, n_columns), dtype='f', order='F')
+                    # Create an array of zeros
+                    np_array1 = np.zeros((n_rows, n_columns), dtype='f', order='F')
 
-            row_begin = 0
-            row_end = 0
+                    row_begin = 0
+                    row_end = 0
 
-            for rg in range(n_row_groups):
-                row_begin = row_end
-                row_end = row_begin + pr.metadata.row_group(rg).num_rows
-                subset_view = np_array1[row_begin:row_end, :] 
-                jj.read_into_numpy (source = path
-                                    , metadata = None
-                                    , np_array = subset_view
-                                    , row_group_indices = [rg]
-                                    , column_indices = range(pr.metadata.num_columns))
+                    for rg in range(n_row_groups):
+                        row_begin = row_end
+                        row_end = row_begin + pr.metadata.row_group(rg).num_rows
+                        subset_view = np_array1[row_begin:row_end, :] 
+                        jj.read_into_numpy (source = path
+                                            , metadata = None
+                                            , np_array = subset_view
+                                            , row_group_indices = [rg]
+                                            , column_indices = range(pr.metadata.num_columns)
+                                            , pre_buffer = pre_buffer
+                                            , use_threads = use_threads
+                                            , use_memory_map = use_memory_map)
 
-            expected_data = pr.read_all()
-            self.assertTrue(np.array_equal(np_array1, expected_data))
+                    expected_data = pr.read_all()
+                    self.assertTrue(np.array_equal(np_array1, expected_data))
 
-            np_array2 = np.zeros((n_rows, n_columns), dtype='f', order='F')
-            jj.read_into_numpy (source = path
-                                , metadata = None
-                                , np_array = np_array2
-                                , row_group_indices = range(pr.metadata.num_row_groups)
-                                , column_indices = range(pr.metadata.num_columns))
+                    np_array2 = np.zeros((n_rows, n_columns), dtype='f', order='F')
+                    jj.read_into_numpy (source = path
+                                        , metadata = None
+                                        , np_array = np_array2
+                                        , row_group_indices = range(pr.metadata.num_row_groups)
+                                        , column_indices = range(pr.metadata.num_columns)
+                                        , pre_buffer = pre_buffer
+                                        , use_threads = use_threads
+                                        , use_memory_map = use_memory_map)
 
-            self.assertTrue(np.array_equal(np_array2, expected_data))
-            pr.close()
+                    self.assertTrue(np.array_equal(np_array2, expected_data))
+                    pr.close()
 
     def test_read_with_palletjack(self):
-        with tempfile.TemporaryDirectory() as tmpdirname:
-            path = os.path.join(tmpdirname, "my.parquet")
-            table = get_table(n_rows, n_columns)
-            pq.write_table(table, path, row_group_size=chunk_size, use_dictionary=False, write_statistics=False, store_schema=False)
+        
+        for pre_buffer, use_threads, use_memory_map in itertools.product ([False, True], [False, True], [False, True]):
+            with self.subTest((pre_buffer, use_threads, use_memory_map)):
+                with tempfile.TemporaryDirectory() as tmpdirname:
+                    path = os.path.join(tmpdirname, "my.parquet")
+                    table = get_table(n_rows, n_columns)
+                    pq.write_table(table, path, row_group_size=chunk_size, use_dictionary=False, write_statistics=False, store_schema=False)
 
-            index_path = path + '.index'
-            pj.generate_metadata_index(path, index_path)
+                    index_path = path + '.index'
+                    pj.generate_metadata_index(path, index_path)
 
-            # Create an array of zeros
-            np_array = np.zeros((n_rows, n_columns), dtype='f', order='F')
+                    # Create an array of zeros
+                    np_array = np.zeros((n_rows, n_columns), dtype='f', order='F')
 
-            row_begin = 0
-            row_end = 0
+                    row_begin = 0
+                    row_end = 0
 
-            for rg in range(n_row_groups):
-                column_indices=list(range(n_columns))
-                metadata = pj.read_metadata(index_path, row_groups=[rg], column_indices=column_indices)
+                    for rg in range(n_row_groups):
+                        column_indices=list(range(n_columns))
+                        metadata = pj.read_metadata(index_path, row_groups=[rg], column_indices=column_indices)
 
-                row_begin = row_end
-                row_end = row_begin + metadata.num_rows
-                subset_view = np_array[row_begin:row_end, :] 
-                jj.read_into_numpy (source = path
-                                    , metadata = metadata
-                                    , np_array = subset_view
-                                    , row_group_indices = [0]
-                                    , column_indices = column_indices)
+                        row_begin = row_end
+                        row_end = row_begin + metadata.num_rows
+                        subset_view = np_array[row_begin:row_end, :] 
+                        jj.read_into_numpy (source = path
+                                            , metadata = metadata
+                                            , np_array = subset_view
+                                            , row_group_indices = [0]
+                                            , column_indices = column_indices
+                                            , pre_buffer = pre_buffer
+                                            , use_threads = use_threads
+                                            , use_memory_map = use_memory_map)
 
-            pr = pq.ParquetReader()
-            pr.open(path)
-            expected_data = pr.read_all()
-            self.assertTrue(np.array_equal(np_array, expected_data))
-            pr.close()
+                    pr = pq.ParquetReader()
+                    pr.open(path)
+                    expected_data = pr.read_all()
+                    self.assertTrue(np.array_equal(np_array, expected_data))
+                    pr.close()
 
     def test_read_nonzero_column_offset(self):
-        with tempfile.TemporaryDirectory() as tmpdirname:
-            path = os.path.join(tmpdirname, "my.parquet")
-            table = get_table(n_rows = chunk_size, n_columns = n_columns)
-            pq.write_table(table, path, row_group_size=chunk_size, use_dictionary=False, write_statistics=False, store_schema=False)
+        
+        for pre_buffer, use_threads, use_memory_map in itertools.product ([False, True], [False, True], [False, True]):
+            with self.subTest((pre_buffer, use_threads, use_memory_map)):
+                
+                with tempfile.TemporaryDirectory() as tmpdirname:
+                    path = os.path.join(tmpdirname, "my.parquet")
+                    table = get_table(n_rows = chunk_size, n_columns = n_columns)
+                    pq.write_table(table, path, row_group_size=chunk_size, use_dictionary=False, write_statistics=False, store_schema=False)
 
-            # Create an array of zeros
-            cols = 2
-            offset = n_columns - cols
-            np_array = np.zeros((chunk_size, cols), dtype='f', order='F')
+                    # Create an array of zeros
+                    cols = 2
+                    offset = n_columns - cols
+                    np_array = np.zeros((chunk_size, cols), dtype='f', order='F')
 
-            jj.read_into_numpy (source = path
-                                , metadata = None
-                                , np_array = np_array
-                                , row_group_indices = [0]
-                                , column_indices = range(offset, offset + cols))
+                    jj.read_into_numpy (source = path
+                                        , metadata = None
+                                        , np_array = np_array
+                                        , row_group_indices = [0]
+                                        , column_indices = range(offset, offset + cols)
+                                        , pre_buffer = pre_buffer
+                                        , use_threads = use_threads
+                                        , use_memory_map = use_memory_map)
 
-            pr = pq.ParquetReader()
-            pr.open(path)
-            expected_data = pr.read_all(column_indices = range(offset, offset + cols))
-            self.assertTrue(np.array_equal(np_array, expected_data))
-            pr.close()
+                    pr = pq.ParquetReader()
+                    pr.open(path)
+                    expected_data = pr.read_all(column_indices = range(offset, offset + cols))
+                    self.assertTrue(np.array_equal(np_array, expected_data))
+                    pr.close()
 
     def test_read_unsupported_column_types(self):
-         with tempfile.TemporaryDirectory() as tmpdirname:
-            path = os.path.join(tmpdirname, "my.parquet")
-            table = get_table(n_rows = chunk_size, n_columns = n_columns, data_type = pa.bool_())
-            pq.write_table(table, path, row_group_size=chunk_size, use_dictionary=False, write_statistics=False, store_schema=False)
+        
+        for pre_buffer, use_threads, use_memory_map in itertools.product ([False, True], [False, True], [False, True]):
+            with self.subTest((pre_buffer, use_threads, use_memory_map)):
+                with tempfile.TemporaryDirectory() as tmpdirname:
+                    path = os.path.join(tmpdirname, "my.parquet")
+                    table = get_table(n_rows = chunk_size, n_columns = n_columns, data_type = pa.bool_())
+                    pq.write_table(table, path, row_group_size=chunk_size, use_dictionary=False, write_statistics=False, store_schema=False)
 
-            # Create an array of zerosx
-            np_array = np.zeros((chunk_size, n_columns), dtype='f', order='F')
+                    # Create an array of zerosx
+                    np_array = np.zeros((chunk_size, n_columns), dtype='f', order='F')
 
-            with self.assertRaises(RuntimeError) as context:
-                jj.read_into_numpy (source = path
-                                    , metadata = None
-                                    , np_array = np_array
-                                    , row_group_indices = [0]
-                                    , column_indices = range(n_columns))
+                    with self.assertRaises(RuntimeError) as context:
+                        jj.read_into_numpy (source = path
+                                            , metadata = None
+                                            , np_array = np_array
+                                            , row_group_indices = [0]
+                                            , column_indices = range(n_columns)
+                                            , pre_buffer = pre_buffer
+                                            , use_threads = use_threads
+                                            , use_memory_map = use_memory_map)
 
             self.assertTrue(f"Column[0] ('column_0') has unsupported data type: 0!" in str(context.exception), context.exception)
                         
@@ -243,127 +272,152 @@ class TestJollyJack(unittest.TestCase):
 
     def test_read_numpy_column_names(self):
 
-        with tempfile.TemporaryDirectory() as tmpdirname:
-            path = os.path.join(tmpdirname, "my.parquet")
-            table = get_table(n_rows = n_rows, n_columns = n_columns, data_type = pa.float32())
-            pq.write_table(table, path, row_group_size=chunk_size, use_dictionary=False, write_statistics=False, store_schema=False)
+        for pre_buffer, use_threads, use_memory_map in itertools.product ([False, True], [False, True], [False, True]):
+            with self.subTest((pre_buffer, use_threads, use_memory_map)):
+                with tempfile.TemporaryDirectory() as tmpdirname:
+                    path = os.path.join(tmpdirname, "my.parquet")
+                    table = get_table(n_rows = n_rows, n_columns = n_columns, data_type = pa.float32())
+                    pq.write_table(table, path, row_group_size=chunk_size, use_dictionary=False, write_statistics=False, store_schema=False)
 
-            # Create an empty array
-            np_array = np.zeros((n_rows, n_columns), dtype=pa.float32().to_pandas_dtype(), order='F')
+                    # Create an empty array
+                    np_array = np.zeros((n_rows, n_columns), dtype=pa.float32().to_pandas_dtype(), order='F')
 
-            jj.read_into_numpy (source = path
-                                , metadata = None
-                                , np_array = np_array
-                                , row_group_indices = range(n_row_groups)
-                                , column_names = [f'column_{i}' for i in range(n_columns)]
-                                )
+                    jj.read_into_numpy (source = path
+                                        , metadata = None
+                                        , np_array = np_array
+                                        , row_group_indices = range(n_row_groups)
+                                        , column_names = [f'column_{i}' for i in range(n_columns)]
+                                        , pre_buffer = pre_buffer
+                                        , use_threads = use_threads
+                                        , use_memory_map = use_memory_map)
 
-            pr = pq.ParquetReader()
-            pr.open(path)
-            expected_data = pr.read_all().to_pandas().to_numpy()
-            self.assertTrue(np.array_equal(np_array, expected_data), f"{np_array}\n{expected_data}")
-            pr.close()
+                    pr = pq.ParquetReader()
+                    pr.open(path)
+                    expected_data = pr.read_all().to_pandas().to_numpy()
+                    self.assertTrue(np.array_equal(np_array, expected_data), f"{np_array}\n{expected_data}")
+                    pr.close()
 
     def test_read_torch_column_names(self):
 
         import torch
 
-        with tempfile.TemporaryDirectory() as tmpdirname:
-            path = os.path.join(tmpdirname, "my.parquet")
-            table = get_table(n_rows = n_rows, n_columns = n_columns, data_type = pa.float32())
-            pq.write_table(table, path, row_group_size=chunk_size, use_dictionary=False, write_statistics=False, store_schema=False)
+        for pre_buffer, use_threads, use_memory_map in itertools.product ([False, True], [False, True], [False, True]):
+            with self.subTest((pre_buffer, use_threads, use_memory_map)):
+                with tempfile.TemporaryDirectory() as tmpdirname:
+                    path = os.path.join(tmpdirname, "my.parquet")
+                    table = get_table(n_rows = n_rows, n_columns = n_columns, data_type = pa.float32())
+                    pq.write_table(table, path, row_group_size=chunk_size, use_dictionary=False, write_statistics=False, store_schema=False)
 
-            # Create an empty array
-            tensor = torch.zeros(n_columns, n_rows, dtype = torch.float32).transpose(0, 1)
+                    # Create an empty array
+                    tensor = torch.zeros(n_columns, n_rows, dtype = torch.float32).transpose(0, 1)
 
-            jj.read_into_torch (source = path
-                                , metadata = None
-                                , tensor = tensor
-                                , row_group_indices = range(n_row_groups)
-                                , column_names = [f'column_{i}' for i in range(n_columns)]
-                                )
+                    jj.read_into_torch (source = path
+                                        , metadata = None
+                                        , tensor = tensor
+                                        , row_group_indices = range(n_row_groups)
+                                        , column_names = [f'column_{i}' for i in range(n_columns)]
+                                        , pre_buffer = pre_buffer
+                                        , use_threads = use_threads
+                                        , use_memory_map = use_memory_map)
 
-            pr = pq.ParquetReader()
-            pr.open(path)
-            expected_data = pr.read_all().to_pandas().to_numpy()
-            self.assertTrue(np.array_equal(tensor.numpy(), expected_data), f"{tensor.numpy()}\n{expected_data}")
-            pr.close()
+                    pr = pq.ParquetReader()
+                    pr.open(path)
+                    expected_data = pr.read_all().to_pandas().to_numpy()
+                    self.assertTrue(np.array_equal(tensor.numpy(), expected_data), f"{tensor.numpy()}\n{expected_data}")
+                    pr.close()
 
     def test_read_invalid_column(self):
 
-        with tempfile.TemporaryDirectory() as tmpdirname:
-            path = os.path.join(tmpdirname, "my.parquet")
-            table = get_table(n_rows = n_rows, n_columns = n_columns, data_type = pa.float32())
-            pq.write_table(table, path, row_group_size=chunk_size, use_dictionary=False, write_statistics=False, store_schema=False)
-
-            pr = pq.ParquetReader()
-            pr.open(path)
-
-            # Create an empty array
-            np_array = np.zeros((n_rows, n_columns), dtype=pa.float32().to_pandas_dtype(), order='F')
-
-            with self.assertRaises(RuntimeError) as context:
-                jj.read_into_numpy (source = path
-                                    , metadata = None
-                                    , np_array = np_array
-                                    , row_group_indices = range(n_row_groups)
-                                    , column_names = [f'foo_bar_{i}' for i in range(n_columns)]
-                                    )
-
-            self.assertTrue(f"Column 'foo_bar_0' was not found!" in str(context.exception), context.exception)
+        for pre_buffer, use_threads, use_memory_map in itertools.product ([False, True], [False, True], [False, True]):
+            with self.subTest((pre_buffer, use_threads, use_memory_map)):
                 
-            with self.assertRaises(RuntimeError) as context:
-                jj.read_into_numpy (source = path
-                                    , metadata = None
-                                    , np_array = np_array
-                                    , row_group_indices = range(n_row_groups)
-                                    , column_indices = [i + 1 for i in range(n_columns)]
-                                    )
+                with tempfile.TemporaryDirectory() as tmpdirname:
+                    path = os.path.join(tmpdirname, "my.parquet")
+                    table = get_table(n_rows = n_rows, n_columns = n_columns, data_type = pa.float32())
+                    pq.write_table(table, path, row_group_size=chunk_size, use_dictionary=False, write_statistics=False, store_schema=False)
 
-            self.assertTrue(f"Trying to read column index {n_columns} but row group metadata has only {n_columns} columns" in str(context.exception), context.exception)
-            pr.close()
+                    pr = pq.ParquetReader()
+                    pr.open(path)
+
+                    # Create an empty array
+                    np_array = np.zeros((n_rows, n_columns), dtype=pa.float32().to_pandas_dtype(), order='F')
+
+                    with self.assertRaises(RuntimeError) as context:
+                        jj.read_into_numpy (source = path
+                                            , metadata = None
+                                            , np_array = np_array
+                                            , row_group_indices = range(n_row_groups)
+                                            , column_names = [f'foo_bar_{i}' for i in range(n_columns)]
+                                            , pre_buffer = pre_buffer
+                                            , use_threads = use_threads
+                                            , use_memory_map = use_memory_map)
+
+                    self.assertTrue(f"Column 'foo_bar_0' was not found!" in str(context.exception), context.exception)
+                        
+                    with self.assertRaises(RuntimeError) as context:
+                        jj.read_into_numpy (source = path
+                                            , metadata = None
+                                            , np_array = np_array
+                                            , row_group_indices = range(n_row_groups)
+                                            , column_indices = [i + 1 for i in range(n_columns)]
+                                            , pre_buffer = pre_buffer
+                                            , use_threads = use_threads
+                                            , use_memory_map = use_memory_map)
+
+                    self.assertTrue(f"Trying to read column index {n_columns} but row group metadata has only {n_columns} columns" in str(context.exception), context.exception)
+                    pr.close()
 
     def test_read_filesystem(self):
-
+                
         with tempfile.TemporaryDirectory() as tmpdirname:
             path = os.path.join(tmpdirname, "my.parquet")
             table = get_table(n_rows = n_rows, n_columns = n_columns, data_type = pa.float32())
             pq.write_table(table, path, row_group_size=chunk_size, use_dictionary=False, write_statistics=False, store_schema=False)
 
-            # Create an empty array
-            np_array = np.zeros((n_rows, n_columns), dtype=pa.float32().to_pandas_dtype(), order='F')
+            for pre_buffer, use_threads, use_memory_map in itertools.product ([False, True], [False, True], [False, True]):
+                with self.subTest((pre_buffer, use_threads, use_memory_map)):
 
-            with fs.LocalFileSystem().open_input_file(path) as f:
-                jj.read_into_numpy (source = f
-                                    , metadata = None
-                                    , np_array = np_array
-                                    , row_group_indices = range(n_row_groups)
-                                    , column_names = [f'column_{i}' for i in range(n_columns)]
-                                    )
+                    # Create an empty array
+                    np_array = np.zeros((n_rows, n_columns), dtype=pa.float32().to_pandas_dtype(), order='F')
 
-            pr = pq.ParquetReader()
-            pr.open(path)
-            expected_data = pr.read_all().to_pandas().to_numpy()
-            self.assertTrue(np.array_equal(np_array, expected_data), f"{np_array}\n{expected_data}")
-            pr.close()
+                    with fs.LocalFileSystem().open_input_file(path) as f:
+                        jj.read_into_numpy (source = f
+                                            , metadata = None
+                                            , np_array = np_array
+                                            , row_group_indices = range(n_row_groups)
+                                            , column_names = [f'column_{i}' for i in range(n_columns)]
+                                            , pre_buffer = pre_buffer
+                                            , use_threads = use_threads
+                                            , use_memory_map = use_memory_map)
+
+                    pr = pq.ParquetReader()
+                    pr.open(path)
+                    expected_data = pr.read_all().to_pandas().to_numpy()
+                    self.assertTrue(np.array_equal(np_array, expected_data), f"{np_array}\n{expected_data}")
+                    pr.close()
 
     def test_read_invalid_row_group(self):
 
-        with tempfile.TemporaryDirectory() as tmpdirname:
-            path = os.path.join(tmpdirname, "my.parquet")
-            table = get_table(n_rows = n_rows, n_columns = n_columns, data_type = pa.float32())
-            pq.write_table(table, path, row_group_size=chunk_size, use_dictionary=False, write_statistics=False, store_schema=False)
+        for pre_buffer, use_threads, use_memory_map in itertools.product ([False, True], [False, True], [False, True]):
+            with self.subTest((pre_buffer, use_threads, use_memory_map)):
+                
+                with tempfile.TemporaryDirectory() as tmpdirname:
+                    path = os.path.join(tmpdirname, "my.parquet")
+                    table = get_table(n_rows = n_rows, n_columns = n_columns, data_type = pa.float32())
+                    pq.write_table(table, path, row_group_size=chunk_size, use_dictionary=False, write_statistics=False, store_schema=False)
 
-            # Create an empty array
-            np_array = np.zeros((n_rows, n_columns), dtype=pa.float32().to_pandas_dtype(), order='F')
+                    # Create an empty array
+                    np_array = np.zeros((n_rows, n_columns), dtype=pa.float32().to_pandas_dtype(), order='F')
 
-            with self.assertRaises(RuntimeError) as context:
-                jj.read_into_numpy (source = path
-                                    , metadata = None
-                                    , np_array = np_array
-                                    , row_group_indices = [n_row_groups]
-                                    , column_names = [f'column_{i}' for i in range(n_columns)]
-                                    )
+                    with self.assertRaises(RuntimeError) as context:
+                        jj.read_into_numpy (source = path
+                                            , metadata = None
+                                            , np_array = np_array
+                                            , row_group_indices = [n_row_groups]
+                                            , column_names = [f'column_{i}' for i in range(n_columns)]
+                                            , pre_buffer = pre_buffer
+                                            , use_threads = use_threads
+                                            , use_memory_map = use_memory_map)
             
             self.assertTrue(f"Trying to read row group {n_row_groups} but file only has {n_row_groups} row groups" in str(context.exception), context.exception)
 
@@ -378,18 +432,23 @@ class TestJollyJack(unittest.TestCase):
 
             pq.write_table(table, path, row_group_size=chunk_size, use_dictionary=False, write_statistics=False, store_schema=False)
 
-            # Create an empty array
-            np_array = np.zeros((n_rows, n_columns), dtype=pa.float32().to_pandas_dtype(), order='F')
+            for pre_buffer, use_threads, use_memory_map in itertools.product ([False, True], [False, True], [False, True]):
+                with self.subTest((pre_buffer, use_threads, use_memory_map)):
 
-            with self.assertRaises(RuntimeError) as context:
-                jj.read_into_numpy (source = path
-                                    , metadata = None
-                                    , np_array = np_array
-                                    , row_group_indices = range(n_row_groups)
-                                    , column_names = [f'column_{i}' for i in range(n_columns)]
-                                    )
+                    # Create an empty array
+                    np_array = np.zeros((n_rows, n_columns), dtype=pa.float32().to_pandas_dtype(), order='F')
 
-            self.assertTrue(f"Unexpected end of stream. Column[0] ('column_0') contains null values?" in str(context.exception), context.exception)
+                    with self.assertRaises(RuntimeError) as context:
+                        jj.read_into_numpy (source = path
+                                            , metadata = None
+                                            , np_array = np_array
+                                            , row_group_indices = range(n_row_groups)
+                                            , column_names = [f'column_{i}' for i in range(n_columns)]
+                                            , pre_buffer = pre_buffer
+                                            , use_threads = use_threads
+                                            , use_memory_map = use_memory_map)
+
+                    self.assertTrue(f"Unexpected end of stream. Column[0] ('column_0') contains null values?" in str(context.exception), context.exception)
 
     def test_read_not_enough_rows(self):
 
@@ -398,18 +457,23 @@ class TestJollyJack(unittest.TestCase):
             table = get_table(n_rows = n_rows, n_columns = n_columns, data_type = pa.float32())
             pq.write_table(table, path, row_group_size=chunk_size, use_dictionary=False, write_statistics=False, store_schema=False)
 
-            # Create an empty array
-            np_array = np.zeros((n_rows + 1, n_columns), dtype=pa.float32().to_pandas_dtype(), order='F')
+            for pre_buffer, use_threads, use_memory_map in itertools.product ([False, True], [False, True], [False, True]):
+                with self.subTest((pre_buffer, use_threads, use_memory_map)):
 
-            with self.assertRaises(RuntimeError) as context:
-                jj.read_into_numpy (source = path
-                                    , metadata = None
-                                    , np_array = np_array
-                                    , row_group_indices = range(n_row_groups)
-                                    , column_names = [f'column_{i}' for i in range(n_columns)]
-                                    )
+                    # Create an empty array
+                    np_array = np.zeros((n_rows + 1, n_columns), dtype=pa.float32().to_pandas_dtype(), order='F')
 
-            self.assertTrue(f"Expected to read {n_rows + 1} rows, but read only {n_rows}!" in str(context.exception), context.exception)
+                    with self.assertRaises(RuntimeError) as context:
+                        jj.read_into_numpy (source = path
+                                            , metadata = None
+                                            , np_array = np_array
+                                            , row_group_indices = range(n_row_groups)
+                                            , column_names = [f'column_{i}' for i in range(n_columns)]
+                                            , pre_buffer = pre_buffer
+                                            , use_threads = use_threads
+                                            , use_memory_map = use_memory_map)
+
+                    self.assertTrue(f"Expected to read {n_rows + 1} rows, but read only {n_rows}!" in str(context.exception), context.exception)
 
     def test_read_numpy_column_names_mapping(self):
 
@@ -418,32 +482,39 @@ class TestJollyJack(unittest.TestCase):
             table = get_table(n_rows = n_rows, n_columns = n_columns, data_type = pa.float32())
             pq.write_table(table, path, row_group_size=chunk_size, use_dictionary=False, write_statistics=False, store_schema=False)
 
-            # Create an empty array
-            np_array = np.zeros((n_rows, n_columns), dtype=pa.float32().to_pandas_dtype(), order='F')
-            jj.read_into_numpy (source = path
-                                , metadata = None
-                                , np_array = np_array
-                                , row_group_indices = range(n_row_groups)
-                                , column_names = {f'column_{i}':n_columns - i - 1 for i in range(n_columns)}
-                                )
-        
-            pr = pq.ParquetReader()
-            pr.open(path)
-            expected_data = pr.read_all().to_pandas().to_numpy()
-            reversed_expected_data = expected_data[:, ::-1]
-            self.assertTrue(np.array_equal(np_array, reversed_expected_data), f"\n{np_array}\n\n{reversed_expected_data}")
-            
-            np_array = np.zeros((n_rows, n_columns), dtype=pa.float32().to_pandas_dtype(), order='F')
-            for c in range(n_columns):
-                jj.read_into_numpy (source = path
-                                    , metadata = None
-                                    , np_array = np_array
-                                    , row_group_indices = range(n_row_groups)
-                                    , column_names = {f'column_{c}':n_columns - c - 1}
-                                    )
+            for pre_buffer, use_threads, use_memory_map in itertools.product ([False, True], [False, True], [False, True]):
+                with self.subTest((pre_buffer, use_threads, use_memory_map)):
 
-            self.assertTrue(np.array_equal(np_array, reversed_expected_data), f"\n{np_array}\n\n{reversed_expected_data}")
-            pr.close()
+                    # Create an empty array
+                    np_array = np.zeros((n_rows, n_columns), dtype=pa.float32().to_pandas_dtype(), order='F')
+                    jj.read_into_numpy (source = path
+                                        , metadata = None
+                                        , np_array = np_array
+                                        , row_group_indices = range(n_row_groups)
+                                        , column_names = {f'column_{i}':n_columns - i - 1 for i in range(n_columns)}
+                                        , pre_buffer = pre_buffer
+                                        , use_threads = use_threads
+                                        , use_memory_map = use_memory_map)
+                
+                    pr = pq.ParquetReader()
+                    pr.open(path)
+                    expected_data = pr.read_all().to_pandas().to_numpy()
+                    reversed_expected_data = expected_data[:, ::-1]
+                    self.assertTrue(np.array_equal(np_array, reversed_expected_data), f"\n{np_array}\n\n{reversed_expected_data}")
+                    
+                    np_array = np.zeros((n_rows, n_columns), dtype=pa.float32().to_pandas_dtype(), order='F')
+                    for c in range(n_columns):
+                        jj.read_into_numpy (source = path
+                                            , metadata = None
+                                            , np_array = np_array
+                                            , row_group_indices = range(n_row_groups)
+                                            , column_names = {f'column_{c}':n_columns - c - 1}
+                                            , pre_buffer = pre_buffer
+                                            , use_threads = use_threads
+                                            , use_memory_map = use_memory_map)
+
+                    self.assertTrue(np.array_equal(np_array, reversed_expected_data), f"\n{np_array}\n\n{reversed_expected_data}")
+                    pr.close()
             
     def test_read_numpy_column_indices_mapping(self):
 
@@ -452,32 +523,39 @@ class TestJollyJack(unittest.TestCase):
             table = get_table(n_rows = n_rows, n_columns = n_columns, data_type = pa.float32())
             pq.write_table(table, path, row_group_size=chunk_size, use_dictionary=False, write_statistics=False, store_schema=False)
 
-            # Create an empty array
-            np_array = np.zeros((n_rows, n_columns), dtype=pa.float32().to_pandas_dtype(), order='F')
-            jj.read_into_numpy (source = path
-                                , metadata = None
-                                , np_array = np_array
-                                , row_group_indices = range(n_row_groups)
-                                , column_indices = {i:n_columns - i - 1 for i in range(n_columns)}
-                                )
+            for pre_buffer, use_threads, use_memory_map in itertools.product ([False, True], [False, True], [False, True]):
+                with self.subTest((pre_buffer, use_threads, use_memory_map)):
 
-            pr = pq.ParquetReader()
-            pr.open(path)
-            expected_data = pr.read_all().to_pandas().to_numpy()
-            reversed_expected_data = expected_data[:, ::-1]
-            self.assertTrue(np.array_equal(np_array, reversed_expected_data), f"\n{np_array}\n\n{reversed_expected_data}")
-             
-            np_array = np.zeros((n_rows, n_columns), dtype=pa.float32().to_pandas_dtype(), order='F')
-            for c in range(n_columns):
-                jj.read_into_numpy (source = path
-                                    , metadata = None
-                                    , np_array = np_array
-                                    , row_group_indices = range(n_row_groups)
-                                    , column_indices = {c : n_columns - c - 1}
-                                    )
+                    # Create an empty array
+                    np_array = np.zeros((n_rows, n_columns), dtype=pa.float32().to_pandas_dtype(), order='F')
+                    jj.read_into_numpy (source = path
+                                        , metadata = None
+                                        , np_array = np_array
+                                        , row_group_indices = range(n_row_groups)
+                                        , column_indices = {i:n_columns - i - 1 for i in range(n_columns)}
+                                        , pre_buffer = pre_buffer
+                                        , use_threads = use_threads
+                                        , use_memory_map = use_memory_map)
 
-            self.assertTrue(np.array_equal(np_array, reversed_expected_data), f"\n{np_array}\n\n{reversed_expected_data}")
-            pr.close()
+                    pr = pq.ParquetReader()
+                    pr.open(path)
+                    expected_data = pr.read_all().to_pandas().to_numpy()
+                    reversed_expected_data = expected_data[:, ::-1]
+                    self.assertTrue(np.array_equal(np_array, reversed_expected_data), f"\n{np_array}\n\n{reversed_expected_data}")
+                    
+                    np_array = np.zeros((n_rows, n_columns), dtype=pa.float32().to_pandas_dtype(), order='F')
+                    for c in range(n_columns):
+                        jj.read_into_numpy (source = path
+                                            , metadata = None
+                                            , np_array = np_array
+                                            , row_group_indices = range(n_row_groups)
+                                            , column_indices = {c : n_columns - c - 1}
+                                            , pre_buffer = pre_buffer
+                                            , use_threads = use_threads
+                                            , use_memory_map = use_memory_map)
+
+                    self.assertTrue(np.array_equal(np_array, reversed_expected_data), f"\n{np_array}\n\n{reversed_expected_data}")
+                    pr.close()
             
     def test_read_large_array(self):
 

--- a/test/test_jollyjack.py
+++ b/test/test_jollyjack.py
@@ -180,9 +180,9 @@ class TestJollyJack(unittest.TestCase):
                                     , use_memory_map = use_memory_map)
 
             self.assertTrue(f"Column[0] ('column_0') has unsupported data type: 0!" in str(context.exception), context.exception)
-                
+
     def test_read_dtype_numpy(self):
-        
+
         for pre_buffer in [False, True]:
             for use_threads in [False, True]:
                 for dtype in [pa.float16(), pa.float32(), pa.float64()]:
@@ -225,8 +225,6 @@ class TestJollyJack(unittest.TestCase):
                                 pr.close()
 
     def test_read_dtype_torch(self):
-        
-        import torch
 
         numpy_to_torch_dtype_dict = {
                 np.bool       : torch.bool,
@@ -338,9 +336,6 @@ class TestJollyJack(unittest.TestCase):
             table = get_table(n_rows = n_rows, n_columns = n_columns, data_type = pa.float32())
             pq.write_table(table, path, row_group_size=chunk_size, use_dictionary=False, write_statistics=False, store_schema=False)
 
-            pr = pq.ParquetReader()
-            pr.open(path)
-
             # Create an empty array
             np_array = np.zeros((n_rows, n_columns), dtype=pa.float32().to_pandas_dtype(), order='F')
 
@@ -366,12 +361,10 @@ class TestJollyJack(unittest.TestCase):
                                     , use_threads = use_threads
                                     , use_memory_map = use_memory_map)
 
-            if pre_buffer:                
+            if pre_buffer:
                 self.assertTrue(f"The file only has {n_columns} columns, requested metadata for column: {n_columns}" in str(context.exception), context.exception)
             else:
                 self.assertTrue(f"Trying to read column index {n_columns} but row group metadata has only {n_columns} columns" in str(context.exception), context.exception)
-
-            pr.close()
 
     @for_each_parameter()
     def test_read_filesystem(self, pre_buffer, use_threads, use_memory_map):
@@ -421,7 +414,7 @@ class TestJollyJack(unittest.TestCase):
                                     , use_threads = use_threads
                                     , use_memory_map = use_memory_map)
 
-            if pre_buffer:                
+            if pre_buffer:
                 self.assertTrue(f"The file only has {n_row_groups} row groups, requested metadata for row group: {n_row_groups}" in str(context.exception), context.exception)
             else:
                 self.assertTrue(f"Trying to read row group {n_row_groups} but file only has {n_row_groups} row groups" in str(context.exception), context.exception)
@@ -553,7 +546,7 @@ class TestJollyJack(unittest.TestCase):
 
             self.assertTrue(np.array_equal(np_array, reversed_expected_data), f"\n{np_array}\n\n{reversed_expected_data}")
             pr.close()
-            
+
     def test_read_large_array(self):
 
         n_row_groups = 1

--- a/test/test_jollyjack.py
+++ b/test/test_jollyjack.py
@@ -179,7 +179,7 @@ class TestJollyJack(unittest.TestCase):
                                     , use_threads = use_threads
                                     , use_memory_map = use_memory_map)
 
-        self.assertTrue(f"Column[0] ('column_0') has unsupported data type: 0!" in str(context.exception), context.exception)
+            self.assertTrue(f"Column[0] ('column_0') has unsupported data type: 0!" in str(context.exception), context.exception)
                 
     def test_read_dtype_numpy(self):
         
@@ -366,7 +366,11 @@ class TestJollyJack(unittest.TestCase):
                                     , use_threads = use_threads
                                     , use_memory_map = use_memory_map)
 
-            self.assertTrue(f"Trying to read column index {n_columns} but row group metadata has only {n_columns} columns" in str(context.exception), context.exception)
+            if pre_buffer:                
+                self.assertTrue(f"The file only has {n_columns} columns, requested metadata for column: {n_columns}" in str(context.exception), context.exception)
+            else:
+                self.assertTrue(f"Trying to read column index {n_columns} but row group metadata has only {n_columns} columns" in str(context.exception), context.exception)
+
             pr.close()
 
     @for_each_parameter()
@@ -416,8 +420,11 @@ class TestJollyJack(unittest.TestCase):
                                     , pre_buffer = pre_buffer
                                     , use_threads = use_threads
                                     , use_memory_map = use_memory_map)
-    
-        self.assertTrue(f"Trying to read row group {n_row_groups} but file only has {n_row_groups} row groups" in str(context.exception), context.exception)
+
+            if pre_buffer:                
+                self.assertTrue(f"The file only has {n_row_groups} row groups, requested metadata for row group: {n_row_groups}" in str(context.exception), context.exception)
+            else:
+                self.assertTrue(f"Trying to read row group {n_row_groups} but file only has {n_row_groups} row groups" in str(context.exception), context.exception)
 
     @for_each_parameter()
     def test_read_data_with_nulls(self, pre_buffer, use_threads, use_memory_map):


### PR DESCRIPTION
Different default values just create unnecessary confusion.
Besides, in the `jollyjack_cython.pyi` we already have `use_threads=True`.