### PR TITLE
Arm64 build

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -90,6 +90,7 @@ jobs:
         # We use manylinux_2_28 for ABI compatibility with pyarrow
         # With the default image we were getting "undefined symbol: _ZNK5arrow6Status8ToStringEv" error (e.g https://github.com/ray-project/ray/issues/24566) 
         CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
+        CIBW_MANYLINUX_AARCH64_IMAGE: manylinux_2_28
         CIBW_ARCHS_LINUX: auto aarch64
         # Disable unsupported builds
         CIBW_SKIP: "pp* *_i686 *-musllinux_* *win32 cp313-*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "jollyjack"
-version = "0.10.1"
+version = "0.10.2"
 description = "Read parquet data directly into numpy array"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Using the `manylinux_2_28` for arm64 build (as it turned out to be necessary for PalletJack)