### PR TITLE
Explicit errors message when arrow version mismatch

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -52,7 +52,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [windows-latest]
       fail-fast: false
 
     steps:
@@ -104,7 +104,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [windows-latest]
       fail-fast: false
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -149,41 +149,6 @@ jobs:
     steps:
       - run: echo "All required checks done"
 
-  benchmarks:
-    needs: build
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest]
-      fail-fast: false
-
-    runs-on: ${{ matrix.os }}
-    steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v5
-      with:
-        python-version: "3.10"
-
-    - name: Download artifacts
-      uses: actions/download-artifact@v4
-      with:
-        pattern: dist-*
-        path: dist
-        merge-multiple: true
-
-    - name: Setup torch
-      run: |
-        python3 -m pip install torch --index-url https://download.pytorch.org/whl/cpu
-
-    - name: Run benchmarks
-      run: |
-        python3 -m pip install -r requirements.txt
-        # Keep in mind that if the local and remote versions are the same, the remote version will be installed
-        pip install JollyJack --pre --find-links ./dist --break-system-packages --only-binary=:all:
-        # So now ensure that the local version is installed 
-        pip install JollyJack --pre --find-links ./dist --break-system-packages --only-binary=:all: --force-reinstall --no-index --no-deps
-        python3 ./benchmarks/benchmark_jollyjack.py
-
   publish:
     if: ${{ !github.event.repository.fork && startsWith(github.ref, 'refs/tags/v') }}
     needs: [all-required-checks-done]

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -52,7 +52,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-latest]
+        os: [ubuntu-latest, windows-latest]
       fail-fast: false
 
     steps:
@@ -104,7 +104,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        os: [windows-latest]
+        os: [ubuntu-latest, windows-latest]
       fail-fast: false
 
     runs-on: ${{ matrix.os }}
@@ -148,6 +148,41 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: echo "All required checks done"
+
+  benchmarks:
+    needs: build
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+      fail-fast: false
+
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.10"
+
+    - name: Download artifacts
+      uses: actions/download-artifact@v4
+      with:
+        pattern: dist-*
+        path: dist
+        merge-multiple: true
+
+    - name: Setup torch
+      run: |
+        python3 -m pip install torch --index-url https://download.pytorch.org/whl/cpu
+
+    - name: Run benchmarks
+      run: |
+        python3 -m pip install -r requirements.txt
+        # Keep in mind that if the local and remote versions are the same, the remote version will be installed
+        pip install JollyJack --pre --find-links ./dist --break-system-packages --only-binary=:all:
+        # So now ensure that the local version is installed 
+        pip install JollyJack --pre --find-links ./dist --break-system-packages --only-binary=:all: --force-reinstall --no-index --no-deps
+        python3 ./benchmarks/benchmark_jollyjack.py
 
   publish:
     if: ${{ !github.event.repository.fork && startsWith(github.ref, 'refs/tags/v') }}

--- a/jollyjack/__init__.py
+++ b/jollyjack/__init__.py
@@ -1,4 +1,6 @@
 # Importing pyarrow is necessary to load the runtime libraries
 import pyarrow
 import pyarrow.parquet
+from importlib.metadata import version, requires
 from .jollyjack_cython import *
+

--- a/jollyjack/__init__.py
+++ b/jollyjack/__init__.py
@@ -1,23 +1,15 @@
 # Importing pyarrow is necessary to load the runtime libraries
 
 import pyarrow
-
-# package/__init__.py
-try:
-    from importlib.metadata import version, requires
-    __version__ = version(__package__)  # Uses package metadata
-    dependencies = requires(__package__)
-    print(dependencies)  # List of requirements strings
-
-except ImportError:
-    __version__ = "0.0.1"  # Fallback
-
+from importlib.metadata import version, requires
+__version__ = version(__package__)  # Uses package metadata
+dependencies = requires(__package__)
+pyarrow_req = next((r for r in dependencies if r.startswith('pyarrow')), '')
 
 try:
     from .jollyjack_cython import *
-        
 except ImportError as e:
     if "libarrow.so" in str(e):
-        raise ImportError(f"Unable to load libarrow.so. This version of {__package__}={__version__} is built against arrow  ensure you have pyarrow==17.x installed. Current pyarrow version: {pyarrow.__version__}")
+        raise ImportError(f"This version of {__package__}={__version__} is built against {pyarrow_req}, please ensure you have it installed. Current pyarrow version is {pyarrow.__version__}")
     else:
         raise

--- a/jollyjack/__init__.py
+++ b/jollyjack/__init__.py
@@ -1,6 +1,7 @@
 # Importing pyarrow is necessary to load the runtime libraries
 
 import pyarrow
+
 from importlib.metadata import version, requires
 __version__ = version(__package__)  # Uses package metadata
 dependencies = requires(__package__)
@@ -9,7 +10,7 @@ pyarrow_req = next((r for r in dependencies if r.startswith('pyarrow')), '')
 try:
     from .jollyjack_cython import *
 except ImportError as e:
-    if "libarrow.so" in str(e):
+    if any(x in str(e) for x in ['arrow', 'parquet']):
         raise ImportError(f"This version of {__package__}={__version__} is built against {pyarrow_req}, please ensure you have it installed. Current pyarrow version is {pyarrow.__version__}")
     else:
         raise

--- a/jollyjack/__init__.py
+++ b/jollyjack/__init__.py
@@ -5,5 +5,11 @@ from importlib.metadata import version, requires
 __version__ = version(__package__)  # Uses package metadata
 dependencies = requires(__package__)
 pyarrow_req = next((r for r in dependencies if r.startswith('pyarrow')), '')
+try:
 from .jollyjack_cython import *
+except ImportError as e:
+    if any(x in str(e) for x in ['arrow', 'parquet']):
+        raise ImportError(f"This version of {__package__}={__version__} is built against {pyarrow_req}, please ensure you have it installed. Current pyarrow version is {pyarrow.__version__}")
+    else:
+        raise
 

--- a/jollyjack/__init__.py
+++ b/jollyjack/__init__.py
@@ -1,3 +1,4 @@
 # Importing pyarrow is necessary to load the runtime libraries
+import pyarrow
 import pyarrow.parquet
 from .jollyjack_cython import *

--- a/jollyjack/__init__.py
+++ b/jollyjack/__init__.py
@@ -10,7 +10,7 @@ try:
     from .jollyjack_cython import *
 except ImportError as e:
     if any(x in str(e) for x in ['arrow', 'parquet']):
-        raise ImportError(f"This version of {__package__}={__version__} is built against {pyarrow_req}, please ensure you have it installed. Current pyarrow version is {pyarrow.__version__}")
+        raise ImportError(f"This version of {__package__}={__version__} is built against {pyarrow_req}, please ensure you have it installed. Current pyarrow version is {pyarrow.__version__}. ({str(e)})") from None
     else:
         raise
 

--- a/jollyjack/__init__.py
+++ b/jollyjack/__init__.py
@@ -1,5 +1,6 @@
 # Importing pyarrow is necessary to load the runtime libraries
 import pyarrow
+import pyarrow.parquet
 from importlib.metadata import version, requires
 __version__ = version(__package__)  # Uses package metadata
 dependencies = requires(__package__)

--- a/jollyjack/__init__.py
+++ b/jollyjack/__init__.py
@@ -5,6 +5,7 @@ from importlib.metadata import version, requires
 __version__ = version(__package__)  # Uses package metadata
 dependencies = requires(__package__)
 pyarrow_req = next((r for r in dependencies if r.startswith('pyarrow')), '')
+
 try:
     from .jollyjack_cython import *
 except ImportError as e:

--- a/jollyjack/__init__.py
+++ b/jollyjack/__init__.py
@@ -1,3 +1,23 @@
 # Importing pyarrow is necessary to load the runtime libraries
-import pyarrow.parquet
-from .jollyjack_cython import *
+
+import pyarrow
+
+# package/__init__.py
+try:
+    from importlib.metadata import version, requires
+    __version__ = version(__package__)  # Uses package metadata
+    dependencies = requires(__package__)
+    print(dependencies)  # List of requirements strings
+
+except ImportError:
+    __version__ = "0.0.1"  # Fallback
+
+
+try:
+    from .jollyjack_cython import *
+        
+except ImportError as e:
+    if "libarrow.so" in str(e):
+        raise ImportError(f"Unable to load libarrow.so. This version of {__package__}={__version__} is built against arrow  ensure you have pyarrow==17.x installed. Current pyarrow version: {pyarrow.__version__}")
+    else:
+        raise

--- a/jollyjack/__init__.py
+++ b/jollyjack/__init__.py
@@ -1,6 +1,5 @@
 # Importing pyarrow is necessary to load the runtime libraries
 import pyarrow
-import pyarrow.parquet
 from importlib.metadata import version, requires
 __version__ = version(__package__)  # Uses package metadata
 dependencies = requires(__package__)

--- a/jollyjack/__init__.py
+++ b/jollyjack/__init__.py
@@ -1,16 +1,3 @@
 # Importing pyarrow is necessary to load the runtime libraries
-
-import pyarrow
-
-from importlib.metadata import version, requires
-__version__ = version(__package__)  # Uses package metadata
-dependencies = requires(__package__)
-pyarrow_req = next((r for r in dependencies if r.startswith('pyarrow')), '')
-
-try:
-    from .jollyjack_cython import *
-except ImportError as e:
-    if any(x in str(e) for x in ['arrow', 'parquet']):
-        raise ImportError(f"This version of {__package__}={__version__} is built against {pyarrow_req}, please ensure you have it installed. Current pyarrow version is {pyarrow.__version__}")
-    else:
-        raise
+import pyarrow.parquet
+from .jollyjack_cython import *

--- a/jollyjack/__init__.py
+++ b/jollyjack/__init__.py
@@ -6,7 +6,7 @@ __version__ = version(__package__)  # Uses package metadata
 dependencies = requires(__package__)
 pyarrow_req = next((r for r in dependencies if r.startswith('pyarrow')), '')
 try:
-from .jollyjack_cython import *
+    from .jollyjack_cython import *
 except ImportError as e:
     if any(x in str(e) for x in ['arrow', 'parquet']):
         raise ImportError(f"This version of {__package__}={__version__} is built against {pyarrow_req}, please ensure you have it installed. Current pyarrow version is {pyarrow.__version__}")

--- a/jollyjack/__init__.py
+++ b/jollyjack/__init__.py
@@ -2,5 +2,8 @@
 import pyarrow
 import pyarrow.parquet
 from importlib.metadata import version, requires
+__version__ = version(__package__)  # Uses package metadata
+dependencies = requires(__package__)
+pyarrow_req = next((r for r in dependencies if r.startswith('pyarrow')), '')
 from .jollyjack_cython import *
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "jollyjack"
-version = "0.14.0"
+version = "0.14.1"
 description = "Read parquet data directly into numpy array"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Example exception:
````
Traceback (most recent call last):
  File "/workspace/JollyJack/test/test_jollyjack.py", line 4, in <module>
    import jollyjack as jj
  File "/workspace/JollyJack/jollyjack/__init__.py", line 13, in <module>
    raise ImportError(f"This version of {__package__}={__version__} is built against {pyarrow_req}, please ensure you have it installed. Current pyarrow version is {pyarrow.__version__}. ({str(e)})") from None
ImportError: This version of jollyjack=0.14.1 is built against pyarrow~=19.0.0, please ensure you have it installed. Current pyarrow version is 18.0.0. (libarrow.so.1900: cannot open shared object file: No such file or directory)
````