### PR TITLE
Support `INT{32,64}` in `ReadColumn`

### DIFF
--- a/jollyjack/jollyjack.cc
+++ b/jollyjack/jollyjack.cc
@@ -83,7 +83,7 @@ arrow::Status ReadColumn (int column_index
 
     int64_t values_read = 0;
     char *base_ptr = (char *)buffer;
-
+    
     int64_t rows_to_read = num_rows;
     while (true)
     {
@@ -113,8 +113,8 @@ arrow::Status ReadColumn (int column_index
       size_t required_size = target_offset + rows_to_read * stride0_size;
 
       if (target_offset >= buffer_size)
-      {
-          auto msg = std::string("Buffer overrun error:")
+      {        
+          auto msg = std::string("Buffer overrun error:")          
             + " Attempted to read " + std::to_string(num_rows) + " rows into location [" + std::to_string(target_row)
             + ", " + std::to_string(target_column) + "], but that is beyond target's boundaries.";
 
@@ -124,7 +124,7 @@ arrow::Status ReadColumn (int column_index
       if (required_size > buffer_size)
       {
           auto left_space = (buffer_size - target_offset) / stride0_size;
-          auto msg = std::string("Buffer overrun error:")
+          auto msg = std::string("Buffer overrun error:")          
             + " Attempted to read " + std::to_string(num_rows) + " rows into location [" + std::to_string(target_row)
             + ", " + std::to_string(target_column) + "], but there was space available for only " + std::to_string(left_space) + " rows.";
 
@@ -177,7 +177,7 @@ arrow::Status ReadColumn (int column_index
         {
           if (stride0_size != column_reader->descr()->type_length())
           {
-            auto msg = std::string("Column[" + std::to_string(parquet_column) + "] ('"  + column_name + "') has FIXED_LEN_BYTE_ARRAY data type with size " + std::to_string(column_reader->descr()->type_length()) +
+            auto msg = std::string("Column[" + std::to_string(parquet_column) + "] ('"  + column_name + "') has FIXED_LEN_BYTE_ARRAY data type with size " + std::to_string(column_reader->descr()->type_length()) + 
               ", but the target value size is " + std::to_string(stride0_size) + "!");
             return arrow::Status::UnknownError(msg);
           }
@@ -255,7 +255,7 @@ arrow::Status ReadColumn (int column_index
           auto msg = std::string("Column[" + std::to_string(parquet_column) + "] ('"  + column_name + "') has unsupported data type: " + std::to_string(column_reader->descr()->physical_type()) + "!");
           return arrow::Status::UnknownError(msg);
         }
-      }
+      }      
 
       if (values_read == num_rows)
         break;
@@ -317,7 +317,7 @@ void ReadIntoMemory (std::shared_ptr<arrow::io::RandomAccessFile> source
       for (auto column_name : column_names)
       {
         auto column_index = schema->ColumnIndex(column_name);
-
+         
         if (column_index < 0)
         {
           auto msg = std::string("Column '") + column_name + "' was not found!";
@@ -359,7 +359,7 @@ void ReadIntoMemory (std::shared_ptr<arrow::io::RandomAccessFile> source
 #endif
 
   auto result = ::arrow::internal::OptionalParallelFor(use_threads, column_indices.size(),
-            [&](int target_column) {
+            [&](int target_column) { 
               return ReadColumn(target_column
                 , target_row
                 , row_group_reader
@@ -480,20 +480,20 @@ void CopyToRowMajor (void* src_buffer, size_t src_stride0_size, size_t src_strid
         {
             int src_col_limit = std::min(src_cols, block_col + BLOCK_SIZE);
             size_t src_offset_1 = src_offset_0;
-
+            
             for (int block_row = 0; block_row < src_rows; block_row += BLOCK_SIZE,
                   src_offset_1 += src_stride0_size * BLOCK_SIZE)
             {
                 int src_row_limit = std::min(src_rows, block_row + BLOCK_SIZE);
                 size_t src_offset_2 = src_offset_1;
-
+                
                 for (int src_row = block_row; src_row < src_row_limit; src_row++,
                       src_offset_2 += src_stride0_size)
                 {
                     int dst_row = row_indices[src_row];
                     size_t src_offset = src_offset_2;
                     size_t dst_offset = dst_stride0_size * dst_row + dst_offset_0;
-
+                    
                     // Process 4 elements at a time using SSE
                     for (int src_col = block_col; src_col <= src_col_limit - SSE_VECTOR_SIZE;
                           src_col += SSE_VECTOR_SIZE,
@@ -531,28 +531,28 @@ void CopyToRowMajor (void* src_buffer, size_t src_stride0_size, size_t src_strid
 
       size_t src_offset_0 = 0;
       size_t dst_offset_0 = 0;
-      for (int block_col = 0; block_col < src_cols; block_col += BLOCK_SIZE,
-            src_offset_0 += src_stride1_size * BLOCK_SIZE,
+      for (int block_col = 0; block_col < src_cols; block_col += BLOCK_SIZE, 
+            src_offset_0 += src_stride1_size * BLOCK_SIZE, 
             dst_offset_0 += dst_stride1_size * BLOCK_SIZE)
       {
         int src_col_limit = std::min(src_cols, block_col + BLOCK_SIZE);
         size_t src_offset_1 = src_offset_0;
-
+        
         for (int block_row = 0; block_row < src_rows; block_row += BLOCK_SIZE,
               src_offset_1 += src_stride0_size * BLOCK_SIZE)
         {
             int src_row_limit = std::min(src_rows, block_row + BLOCK_SIZE);
             size_t src_offset_2 = src_offset_1;
-
+            
             for (int src_row = block_row; src_row < src_row_limit; src_row++,
                   src_offset_2 += src_stride0_size)
             {
                 int dst_row = row_indices[src_row];
                 size_t src_offset = src_offset_2;
                 size_t dst_offset = dst_stride0_size * dst_row + dst_offset_0;
-
+                
                 // Process 4 elements at a time using SSE
-                for (int src_col = block_col; src_col <= src_col_limit - SSE_VECTOR_SIZE;
+                for (int src_col = block_col; src_col <= src_col_limit - SSE_VECTOR_SIZE; 
                       src_col += SSE_VECTOR_SIZE,
                       dst_offset += dst_stride1_size * SSE_VECTOR_SIZE,
                       src_offset += src_stride1_size * SSE_VECTOR_SIZE)
@@ -572,7 +572,7 @@ void CopyToRowMajor (void* src_buffer, size_t src_stride0_size, size_t src_strid
                     // Store the vector to destination (destination is contiguous in memory)
                     _mm_storeu_si128((__m128i*)&dst_ptr[dst_offset], v);
                 }
-
+                
                 // Handle remaining elements
                 for (int src_col = src_col_limit - (src_col_limit - block_col) % SSE_VECTOR_SIZE;
                       src_col < src_col_limit;
@@ -586,7 +586,7 @@ void CopyToRowMajor (void* src_buffer, size_t src_stride0_size, size_t src_strid
         }
       }
     }
-    else
+    else 
     {
       // Fall back to original implementation for other sizes
       size_t src_offset_0 = 0;
@@ -597,20 +597,20 @@ void CopyToRowMajor (void* src_buffer, size_t src_stride0_size, size_t src_strid
       {
         int src_col_limit = std::min(src_cols, block_col + BLOCK_SIZE);
         size_t src_offset_1 = src_offset_0;
-
+        
         for (int block_row = 0; block_row < src_rows; block_row += BLOCK_SIZE,
               src_offset_1 += src_stride0_size * BLOCK_SIZE)
         {
             int src_row_limit = std::min(src_rows, block_row + BLOCK_SIZE);
             size_t src_offset_2 = src_offset_1;
-
+            
             for (int src_row = block_row; src_row < src_row_limit; src_row++,
                   src_offset_2 += src_stride0_size)
             {
                 int dst_row = row_indices[src_row];
                 size_t src_offset = src_offset_2;
                 size_t dst_offset = dst_stride0_size * dst_row + dst_offset_0;
-
+                
                 for (int src_col = block_col; src_col < src_col_limit; src_col++,
                       dst_offset += dst_stride1_size,
                       src_offset += src_stride1_size)

--- a/jollyjack/jollyjack.cc
+++ b/jollyjack/jollyjack.cc
@@ -83,7 +83,7 @@ arrow::Status ReadColumn (int column_index
 
     int64_t values_read = 0;
     char *base_ptr = (char *)buffer;
-    
+
     int64_t rows_to_read = num_rows;
     while (true)
     {
@@ -113,8 +113,8 @@ arrow::Status ReadColumn (int column_index
       size_t required_size = target_offset + rows_to_read * stride0_size;
 
       if (target_offset >= buffer_size)
-      {        
-          auto msg = std::string("Buffer overrun error:")          
+      {
+          auto msg = std::string("Buffer overrun error:")
             + " Attempted to read " + std::to_string(num_rows) + " rows into location [" + std::to_string(target_row)
             + ", " + std::to_string(target_column) + "], but that is beyond target's boundaries.";
 
@@ -124,7 +124,7 @@ arrow::Status ReadColumn (int column_index
       if (required_size > buffer_size)
       {
           auto left_space = (buffer_size - target_offset) / stride0_size;
-          auto msg = std::string("Buffer overrun error:")          
+          auto msg = std::string("Buffer overrun error:")
             + " Attempted to read " + std::to_string(num_rows) + " rows into location [" + std::to_string(target_row)
             + ", " + std::to_string(target_column) + "], but there was space available for only " + std::to_string(left_space) + " rows.";
 
@@ -177,7 +177,7 @@ arrow::Status ReadColumn (int column_index
         {
           if (stride0_size != column_reader->descr()->type_length())
           {
-            auto msg = std::string("Column[" + std::to_string(parquet_column) + "] ('"  + column_name + "') has FIXED_LEN_BYTE_ARRAY data type with size " + std::to_string(column_reader->descr()->type_length()) + 
+            auto msg = std::string("Column[" + std::to_string(parquet_column) + "] ('"  + column_name + "') has FIXED_LEN_BYTE_ARRAY data type with size " + std::to_string(column_reader->descr()->type_length()) +
               ", but the target value size is " + std::to_string(stride0_size) + "!");
             return arrow::Status::UnknownError(msg);
           }
@@ -210,12 +210,52 @@ arrow::Status ReadColumn (int column_index
           break;
         }
 
+        case parquet::Type::INT32:
+        {
+          if (stride0_size != 4)
+          {
+            auto msg = std::string("Column[" + std::to_string(parquet_column) + "] ('" + column_name + "') has INT32 data type, but the target value size is " + std::to_string(stride0_size) + "!");
+            return arrow::Status::UnknownError(msg);
+          }
+
+          auto typed_reader = static_cast<parquet::Int32Reader *>(column_reader.get());
+          while (rows_to_read > 0)
+          {
+            int64_t tmp_values_read = 0;
+            auto read_levels = typed_reader->ReadBatch(rows_to_read, nullptr, nullptr, (int32_t *)&base_ptr[target_offset], &tmp_values_read);
+            target_offset += tmp_values_read * stride0_size;
+            values_read += tmp_values_read;
+            rows_to_read -= tmp_values_read;
+          }
+          break;
+        }
+
+        case parquet::Type::INT64:
+        {
+          if (stride0_size != 8)
+          {
+            auto msg = std::string("Column[" + std::to_string(parquet_column) + "] ('" + column_name + "') has INT64 data type, but the target value size is " + std::to_string(stride0_size) + "!");
+            return arrow::Status::UnknownError(msg);
+          }
+
+          auto typed_reader = static_cast<parquet::Int64Reader *>(column_reader.get());
+          while (rows_to_read > 0)
+          {
+            int64_t tmp_values_read = 0;
+            auto read_levels = typed_reader->ReadBatch(rows_to_read, nullptr, nullptr, (int64_t *)&base_ptr[target_offset], &tmp_values_read);
+            target_offset += tmp_values_read * stride0_size;
+            values_read += tmp_values_read;
+            rows_to_read -= tmp_values_read;
+          }
+          break;
+        }
+
         default:
         {
           auto msg = std::string("Column[" + std::to_string(parquet_column) + "] ('"  + column_name + "') has unsupported data type: " + std::to_string(column_reader->descr()->physical_type()) + "!");
           return arrow::Status::UnknownError(msg);
         }
-      }      
+      }
 
       if (values_read == num_rows)
         break;
@@ -277,7 +317,7 @@ void ReadIntoMemory (std::shared_ptr<arrow::io::RandomAccessFile> source
       for (auto column_name : column_names)
       {
         auto column_index = schema->ColumnIndex(column_name);
-         
+
         if (column_index < 0)
         {
           auto msg = std::string("Column '") + column_name + "' was not found!";
@@ -319,7 +359,7 @@ void ReadIntoMemory (std::shared_ptr<arrow::io::RandomAccessFile> source
 #endif
 
   auto result = ::arrow::internal::OptionalParallelFor(use_threads, column_indices.size(),
-            [&](int target_column) { 
+            [&](int target_column) {
               return ReadColumn(target_column
                 , target_row
                 , row_group_reader
@@ -440,20 +480,20 @@ void CopyToRowMajor (void* src_buffer, size_t src_stride0_size, size_t src_strid
         {
             int src_col_limit = std::min(src_cols, block_col + BLOCK_SIZE);
             size_t src_offset_1 = src_offset_0;
-            
+
             for (int block_row = 0; block_row < src_rows; block_row += BLOCK_SIZE,
                   src_offset_1 += src_stride0_size * BLOCK_SIZE)
             {
                 int src_row_limit = std::min(src_rows, block_row + BLOCK_SIZE);
                 size_t src_offset_2 = src_offset_1;
-                
+
                 for (int src_row = block_row; src_row < src_row_limit; src_row++,
                       src_offset_2 += src_stride0_size)
                 {
                     int dst_row = row_indices[src_row];
                     size_t src_offset = src_offset_2;
                     size_t dst_offset = dst_stride0_size * dst_row + dst_offset_0;
-                    
+
                     // Process 4 elements at a time using SSE
                     for (int src_col = block_col; src_col <= src_col_limit - SSE_VECTOR_SIZE;
                           src_col += SSE_VECTOR_SIZE,
@@ -491,28 +531,28 @@ void CopyToRowMajor (void* src_buffer, size_t src_stride0_size, size_t src_strid
 
       size_t src_offset_0 = 0;
       size_t dst_offset_0 = 0;
-      for (int block_col = 0; block_col < src_cols; block_col += BLOCK_SIZE, 
-            src_offset_0 += src_stride1_size * BLOCK_SIZE, 
+      for (int block_col = 0; block_col < src_cols; block_col += BLOCK_SIZE,
+            src_offset_0 += src_stride1_size * BLOCK_SIZE,
             dst_offset_0 += dst_stride1_size * BLOCK_SIZE)
       {
         int src_col_limit = std::min(src_cols, block_col + BLOCK_SIZE);
         size_t src_offset_1 = src_offset_0;
-        
+
         for (int block_row = 0; block_row < src_rows; block_row += BLOCK_SIZE,
               src_offset_1 += src_stride0_size * BLOCK_SIZE)
         {
             int src_row_limit = std::min(src_rows, block_row + BLOCK_SIZE);
             size_t src_offset_2 = src_offset_1;
-            
+
             for (int src_row = block_row; src_row < src_row_limit; src_row++,
                   src_offset_2 += src_stride0_size)
             {
                 int dst_row = row_indices[src_row];
                 size_t src_offset = src_offset_2;
                 size_t dst_offset = dst_stride0_size * dst_row + dst_offset_0;
-                
+
                 // Process 4 elements at a time using SSE
-                for (int src_col = block_col; src_col <= src_col_limit - SSE_VECTOR_SIZE; 
+                for (int src_col = block_col; src_col <= src_col_limit - SSE_VECTOR_SIZE;
                       src_col += SSE_VECTOR_SIZE,
                       dst_offset += dst_stride1_size * SSE_VECTOR_SIZE,
                       src_offset += src_stride1_size * SSE_VECTOR_SIZE)
@@ -532,7 +572,7 @@ void CopyToRowMajor (void* src_buffer, size_t src_stride0_size, size_t src_strid
                     // Store the vector to destination (destination is contiguous in memory)
                     _mm_storeu_si128((__m128i*)&dst_ptr[dst_offset], v);
                 }
-                
+
                 // Handle remaining elements
                 for (int src_col = src_col_limit - (src_col_limit - block_col) % SSE_VECTOR_SIZE;
                       src_col < src_col_limit;
@@ -546,7 +586,7 @@ void CopyToRowMajor (void* src_buffer, size_t src_stride0_size, size_t src_strid
         }
       }
     }
-    else 
+    else
     {
       // Fall back to original implementation for other sizes
       size_t src_offset_0 = 0;
@@ -557,20 +597,20 @@ void CopyToRowMajor (void* src_buffer, size_t src_stride0_size, size_t src_strid
       {
         int src_col_limit = std::min(src_cols, block_col + BLOCK_SIZE);
         size_t src_offset_1 = src_offset_0;
-        
+
         for (int block_row = 0; block_row < src_rows; block_row += BLOCK_SIZE,
               src_offset_1 += src_stride0_size * BLOCK_SIZE)
         {
             int src_row_limit = std::min(src_rows, block_row + BLOCK_SIZE);
             size_t src_offset_2 = src_offset_1;
-            
+
             for (int src_row = block_row; src_row < src_row_limit; src_row++,
                   src_offset_2 += src_stride0_size)
             {
                 int dst_row = row_indices[src_row];
                 size_t src_offset = src_offset_2;
                 size_t dst_offset = dst_stride0_size * dst_row + dst_offset_0;
-                
+
                 for (int src_col = block_col; src_col < src_col_limit; src_col++,
                       dst_offset += dst_stride1_size,
                       src_offset += src_stride1_size)

--- a/test/test_jollyjack.py
+++ b/test/test_jollyjack.py
@@ -71,7 +71,7 @@ class TestJollyJack(unittest.TestCase):
             for rg in range(n_row_groups):
                 row_begin = row_end
                 row_end = row_begin + pr.metadata.row_group(rg).num_rows
-                subset_view = np_array1[row_begin:row_end, :] 
+                subset_view = np_array1[row_begin:row_end, :]
                 jj.read_into_numpy (source = path
                                     , metadata = None
                                     , np_array = subset_view
@@ -120,7 +120,7 @@ class TestJollyJack(unittest.TestCase):
 
                 row_begin = row_end
                 row_end = row_begin + metadata.num_rows
-                subset_view = np_array[row_begin:row_end, :] 
+                subset_view = np_array[row_begin:row_end, :]
                 jj.read_into_numpy (source = path
                                     , metadata = metadata
                                     , np_array = subset_view
@@ -226,7 +226,7 @@ class TestJollyJack(unittest.TestCase):
 
             self.assertTrue(f"Cannot read column=0 due to unsupported_encoding=DELTA_BYTE_ARRAY!" in str(context.exception), context.exception)
 
-    @parameterized.expand(itertools.product([False, True], [False, True], [False, True], [pa.float16(), pa.float32(), pa.float64()], supported_encodings))
+    @parameterized.expand(itertools.product([False, True], [False, True], [False, True], [pa.float16(), pa.float32(), pa.float64(), pa.int32(), pa.int64()], supported_encodings))
     def test_read_dtype_numpy(self, pre_buffer, use_threads, use_memory_map, dtype, encoding):
 
         for (n_row_groups, n_columns, chunk_size) in [
@@ -235,7 +235,7 @@ class TestJollyJack(unittest.TestCase):
                 (1, 1, 2),
                 (1, 1, 10),
                 (1, 1, 100),
-                (1, 1, 1_000), 
+                (1, 1, 1_000),
                 (1, 1, 10_000),
                 (1, 1, 100_000),
                 (1, 1, 1_000_000),
@@ -268,7 +268,7 @@ class TestJollyJack(unittest.TestCase):
                     self.assertTrue(np.array_equal(np_array, expected_data), f"{np_array}\n{expected_data}")
                     pr.close()
 
-    @parameterized.expand(itertools.product([False, True], [False, True], [False, True], [pa.float16(), pa.float32(), pa.float64()], supported_encodings))
+    @parameterized.expand(itertools.product([False, True], [False, True], [False, True], [pa.float16(), pa.float32(), pa.float64(), pa.int32(), pa.int64()], supported_encodings))
     def test_read_dtype_torch(self, pre_buffer, use_threads, use_memory_map, dtype, encoding):
 
         for (n_row_groups, n_columns, chunk_size) in [
@@ -277,12 +277,12 @@ class TestJollyJack(unittest.TestCase):
                 (1, 1, 2),
                 (1, 1, 10),
                 (1, 1, 100),
-                (1, 1, 1_000), 
+                (1, 1, 1_000),
                 (1, 1, 10_000),
                 (1, 1, 100_000),
                 (1, 1, 1_000_000),
                 (1, 1, 1_000_001),
-            ]:                
+            ]:
 
             with self.subTest((n_row_groups, n_columns, chunk_size, dtype, encoding)):
                 n_rows = n_row_groups * chunk_size
@@ -309,7 +309,7 @@ class TestJollyJack(unittest.TestCase):
                     self.assertTrue(np.array_equal(tensor.numpy(), expected_data), f"{tensor.numpy()}\n{expected_data}")
                     pr.close()
 
-    @parameterized.expand(itertools.product([False, True], [False, True], [False, True], [pa.float16(), pa.float32(), pa.float64()]))
+    @parameterized.expand(itertools.product([False, True], [False, True], [False, True], [pa.float16(), pa.float32(), pa.float64(), pa.int32(), pa.int64()]))
     def test_read_numpy_column_names(self, pre_buffer, use_threads, use_memory_map, dtype):
 
         with tempfile.TemporaryDirectory() as tmpdirname:
@@ -335,7 +335,7 @@ class TestJollyJack(unittest.TestCase):
             self.assertTrue(np.array_equal(np_array, expected_data), f"{np_array}\n{expected_data}")
             pr.close()
 
-    @parameterized.expand(itertools.product([False, True], [False, True], [False, True], [pa.float16(), pa.float32(), pa.float64()]))
+    @parameterized.expand(itertools.product([False, True], [False, True], [False, True], [pa.float16(), pa.float32(), pa.float64(), pa.int32(), pa.int64()]))
     def test_read_torch_column_names(self, pre_buffer, use_threads, use_memory_map, dtype):
 
         with tempfile.TemporaryDirectory() as tmpdirname:
@@ -383,7 +383,7 @@ class TestJollyJack(unittest.TestCase):
                                     , use_memory_map = use_memory_map)
 
             self.assertTrue(f"Column 'foo_bar_0' was not found!" in str(context.exception), context.exception)
-                
+
             with self.assertRaises(RuntimeError) as context:
                 jj.read_into_numpy (source = path
                                     , metadata = None
@@ -401,7 +401,7 @@ class TestJollyJack(unittest.TestCase):
 
     @parameterized.expand(itertools.product([False, True], [False, True], [False, True], [pa.float16(), pa.float32(), pa.float64()]))
     def test_read_filesystem(self, pre_buffer, use_threads, use_memory_map, dtype):
-                
+
         with tempfile.TemporaryDirectory() as tmpdirname:
             path = os.path.join(tmpdirname, "my.parquet")
             table = get_table(n_rows = n_rows, n_columns = n_columns, data_type = dtype)
@@ -519,13 +519,13 @@ class TestJollyJack(unittest.TestCase):
                                 , pre_buffer = pre_buffer
                                 , use_threads = use_threads
                                 , use_memory_map = use_memory_map)
-        
+
             pr = pq.ParquetReader()
             pr.open(path)
             expected_data = pr.read_all().to_pandas().to_numpy()
             reversed_expected_data = expected_data[:, ::-1]
             self.assertTrue(np.array_equal(np_array, reversed_expected_data), f"\n{np_array}\n\n{reversed_expected_data}")
-            
+
             np_array = np.zeros((n_rows, n_columns), dtype=dtype.to_pandas_dtype(), order='F')
             for c in range(n_columns):
                 jj.read_into_numpy (source = path
@@ -547,7 +547,7 @@ class TestJollyJack(unittest.TestCase):
             path = os.path.join(tmpdirname, "my.parquet")
             table = get_table(n_rows = n_rows, n_columns = n_columns, data_type = dtype)
             pq.write_table(table, path, row_group_size=chunk_size, use_dictionary=False, write_statistics=False, store_schema=False)
-  
+
             # Create an empty array
             np_array = np.zeros((n_rows, n_columns), dtype=dtype.to_pandas_dtype(), order='F')
             jj.read_into_numpy (source = path
@@ -564,7 +564,7 @@ class TestJollyJack(unittest.TestCase):
             expected_data = pr.read_all().to_pandas().to_numpy()
             reversed_expected_data = expected_data[:, ::-1]
             self.assertTrue(np.array_equal(np_array, reversed_expected_data), f"\n{np_array}\n\n{reversed_expected_data}")
-            
+
             np_array = np.zeros((n_rows, n_columns), dtype=dtype.to_pandas_dtype(), order='F')
             for c in range(n_columns):
                 jj.read_into_numpy (source = path
@@ -771,7 +771,7 @@ class TestJollyJack(unittest.TestCase):
             self.assertTrue(np.array_equal(np_array, expected_data))
 
             pr.close()
- 
+
     @parameterized.expand(itertools.product([False, True], [False, True], [False, True], [pa.float16(), pa.float32(), pa.float64()]))
     def test_read_partial_table_with_slices(self, pre_buffer, use_threads, use_memory_map, dtype):
 
@@ -818,7 +818,7 @@ class TestJollyJack(unittest.TestCase):
             expected_array[chunk_size:] = expected_data[:chunk_size]
             row_ranges = [slice (chunk_size, 2 * chunk_size), slice(0, 1), slice (1, chunk_size), ]
             tensor = torch.zeros(n_columns, n_rows, dtype = numpy_to_torch_dtype_dict[dtype.to_pandas_dtype()]).transpose(0, 1)
-            
+
             jj.read_into_torch (source = path
                                 , metadata = None
                                 , tensor = tensor
@@ -843,7 +843,7 @@ class TestJollyJack(unittest.TestCase):
             pr.open(path)
 
             np_array = np.zeros((n_rows, n_columns), dtype=dtype.to_pandas_dtype(), order='F')
-            
+
             with self.assertRaises(RuntimeError) as context:
                 jj.read_into_numpy (source = path
                                     , metadata = None
@@ -915,7 +915,7 @@ class TestJollyJack(unittest.TestCase):
                                     , use_memory_map = use_memory_map
                                     , row_ranges = [slice(chunk_size, chunk_size - 1)])
             self.assertTrue(f"Row range 'slice({chunk_size}, {chunk_size - 1}, None)' is not a valid range" in str(context.exception), context.exception)
-            
+
             with self.assertRaises(RuntimeError) as context:
                 jj.read_into_numpy (source = path
                                     , metadata = None
@@ -930,19 +930,19 @@ class TestJollyJack(unittest.TestCase):
 
             pr.close()
 
-    @parameterized.expand(itertools.product([pa.float16(), pa.float32(), pa.float64()], 
-                                            [(1, 1), (5,6),(8, 8), (16, 16), 
-                                             (32, 32), (32, 33), (33, 32), (64, 64), 
+    @parameterized.expand(itertools.product([pa.float16(), pa.float32(), pa.float64()],
+                                            [(1, 1), (5,6),(8, 8), (16, 16),
+                                             (32, 32), (32, 33), (33, 32), (64, 64),
                                              (65, 64), (64, 65), (100, 200), (1000, 2000)]))
     def test_copy_to_numpy_row_major(self, dtype, n_rows_n_columns):
 
         n_rows = n_rows_n_columns[0]
         n_columns = n_rows_n_columns[1]
-        
+
         src_array = get_table(n_rows, n_columns, data_type = dtype).to_pandas().to_numpy()
         dst_array = np.zeros((n_rows, n_columns), dtype=dtype.to_pandas_dtype(), order='C')
         expected_array = np.zeros((n_rows, n_columns), dtype=dtype.to_pandas_dtype(), order='C')
-        np.copyto(expected_array, src_array)                   
+        np.copyto(expected_array, src_array)
         jj.copy_to_numpy_row_major(src_array = src_array, dst_array = dst_array, row_indices = range(n_rows))
         self.assertTrue(np.array_equal(expected_array, dst_array), f"{expected_array}\n!=\n{dst_array}")
 
@@ -952,12 +952,12 @@ class TestJollyJack(unittest.TestCase):
         self.assertTrue(np.array_equal(expected_array, dst_array), f"{expected_array}\n!=\n{dst_array}")
 
         # Subsets
-        src_view = src_array[1:(n_rows - 1), 1:(n_columns - 1)] 
+        src_view = src_array[1:(n_rows - 1), 1:(n_columns - 1)]
         dst_array = np.zeros((n_rows, n_columns), dtype=dtype.to_pandas_dtype(), order='C')
-        dst_view = dst_array[1:(n_rows - 1), 1:(n_columns - 1)] 
+        dst_view = dst_array[1:(n_rows - 1), 1:(n_columns - 1)]
         expected_array = np.zeros((n_rows, n_columns), dtype=dtype.to_pandas_dtype(), order='C')
         np.copyto(expected_array, src_array)
-        expected_array = expected_array[1:(n_rows - 1), 1:(n_columns - 1)]    
+        expected_array = expected_array[1:(n_rows - 1), 1:(n_columns - 1)]
         jj.copy_to_numpy_row_major(src_array = src_view, dst_array = dst_view, row_indices = range(n_rows - 2))
         self.assertTrue(np.array_equal(expected_array, dst_view), f"{expected_array}\n!=\n{dst_view}")
 
@@ -973,7 +973,7 @@ class TestJollyJack(unittest.TestCase):
 
         src_tensor = torch.tensor(get_table(n_rows, n_columns, data_type = dtype).to_pandas().to_numpy())
         dst_tensor = torch.zeros(n_rows, n_columns, dtype = numpy_to_torch_dtype_dict[dtype.to_pandas_dtype()])
-        expected_tensor = src_tensor.clone().contiguous()   
+        expected_tensor = src_tensor.clone().contiguous()
         jj.copy_to_torch_row_major(src_tensor = src_tensor, dst_tensor = dst_tensor, row_indices = range(n_rows))
         self.assertTrue(torch.equal(expected_tensor, dst_tensor), f"{expected_tensor}\n!=\n{dst_tensor}")
 

--- a/test/test_jollyjack.py
+++ b/test/test_jollyjack.py
@@ -71,7 +71,7 @@ class TestJollyJack(unittest.TestCase):
             for rg in range(n_row_groups):
                 row_begin = row_end
                 row_end = row_begin + pr.metadata.row_group(rg).num_rows
-                subset_view = np_array1[row_begin:row_end, :]
+                subset_view = np_array1[row_begin:row_end, :] 
                 jj.read_into_numpy (source = path
                                     , metadata = None
                                     , np_array = subset_view
@@ -120,7 +120,7 @@ class TestJollyJack(unittest.TestCase):
 
                 row_begin = row_end
                 row_end = row_begin + metadata.num_rows
-                subset_view = np_array[row_begin:row_end, :]
+                subset_view = np_array[row_begin:row_end, :] 
                 jj.read_into_numpy (source = path
                                     , metadata = metadata
                                     , np_array = subset_view
@@ -235,7 +235,7 @@ class TestJollyJack(unittest.TestCase):
                 (1, 1, 2),
                 (1, 1, 10),
                 (1, 1, 100),
-                (1, 1, 1_000),
+                (1, 1, 1_000), 
                 (1, 1, 10_000),
                 (1, 1, 100_000),
                 (1, 1, 1_000_000),
@@ -277,12 +277,12 @@ class TestJollyJack(unittest.TestCase):
                 (1, 1, 2),
                 (1, 1, 10),
                 (1, 1, 100),
-                (1, 1, 1_000),
+                (1, 1, 1_000), 
                 (1, 1, 10_000),
                 (1, 1, 100_000),
                 (1, 1, 1_000_000),
                 (1, 1, 1_000_001),
-            ]:
+            ]:                
 
             with self.subTest((n_row_groups, n_columns, chunk_size, dtype, encoding)):
                 n_rows = n_row_groups * chunk_size
@@ -383,7 +383,7 @@ class TestJollyJack(unittest.TestCase):
                                     , use_memory_map = use_memory_map)
 
             self.assertTrue(f"Column 'foo_bar_0' was not found!" in str(context.exception), context.exception)
-
+                
             with self.assertRaises(RuntimeError) as context:
                 jj.read_into_numpy (source = path
                                     , metadata = None
@@ -401,7 +401,7 @@ class TestJollyJack(unittest.TestCase):
 
     @parameterized.expand(itertools.product([False, True], [False, True], [False, True], [pa.float16(), pa.float32(), pa.float64()]))
     def test_read_filesystem(self, pre_buffer, use_threads, use_memory_map, dtype):
-
+                
         with tempfile.TemporaryDirectory() as tmpdirname:
             path = os.path.join(tmpdirname, "my.parquet")
             table = get_table(n_rows = n_rows, n_columns = n_columns, data_type = dtype)
@@ -519,13 +519,13 @@ class TestJollyJack(unittest.TestCase):
                                 , pre_buffer = pre_buffer
                                 , use_threads = use_threads
                                 , use_memory_map = use_memory_map)
-
+        
             pr = pq.ParquetReader()
             pr.open(path)
             expected_data = pr.read_all().to_pandas().to_numpy()
             reversed_expected_data = expected_data[:, ::-1]
             self.assertTrue(np.array_equal(np_array, reversed_expected_data), f"\n{np_array}\n\n{reversed_expected_data}")
-
+            
             np_array = np.zeros((n_rows, n_columns), dtype=dtype.to_pandas_dtype(), order='F')
             for c in range(n_columns):
                 jj.read_into_numpy (source = path
@@ -547,7 +547,7 @@ class TestJollyJack(unittest.TestCase):
             path = os.path.join(tmpdirname, "my.parquet")
             table = get_table(n_rows = n_rows, n_columns = n_columns, data_type = dtype)
             pq.write_table(table, path, row_group_size=chunk_size, use_dictionary=False, write_statistics=False, store_schema=False)
-
+  
             # Create an empty array
             np_array = np.zeros((n_rows, n_columns), dtype=dtype.to_pandas_dtype(), order='F')
             jj.read_into_numpy (source = path
@@ -564,7 +564,7 @@ class TestJollyJack(unittest.TestCase):
             expected_data = pr.read_all().to_pandas().to_numpy()
             reversed_expected_data = expected_data[:, ::-1]
             self.assertTrue(np.array_equal(np_array, reversed_expected_data), f"\n{np_array}\n\n{reversed_expected_data}")
-
+            
             np_array = np.zeros((n_rows, n_columns), dtype=dtype.to_pandas_dtype(), order='F')
             for c in range(n_columns):
                 jj.read_into_numpy (source = path
@@ -771,7 +771,7 @@ class TestJollyJack(unittest.TestCase):
             self.assertTrue(np.array_equal(np_array, expected_data))
 
             pr.close()
-
+ 
     @parameterized.expand(itertools.product([False, True], [False, True], [False, True], [pa.float16(), pa.float32(), pa.float64()]))
     def test_read_partial_table_with_slices(self, pre_buffer, use_threads, use_memory_map, dtype):
 
@@ -818,7 +818,7 @@ class TestJollyJack(unittest.TestCase):
             expected_array[chunk_size:] = expected_data[:chunk_size]
             row_ranges = [slice (chunk_size, 2 * chunk_size), slice(0, 1), slice (1, chunk_size), ]
             tensor = torch.zeros(n_columns, n_rows, dtype = numpy_to_torch_dtype_dict[dtype.to_pandas_dtype()]).transpose(0, 1)
-
+            
             jj.read_into_torch (source = path
                                 , metadata = None
                                 , tensor = tensor
@@ -843,7 +843,7 @@ class TestJollyJack(unittest.TestCase):
             pr.open(path)
 
             np_array = np.zeros((n_rows, n_columns), dtype=dtype.to_pandas_dtype(), order='F')
-
+            
             with self.assertRaises(RuntimeError) as context:
                 jj.read_into_numpy (source = path
                                     , metadata = None
@@ -915,7 +915,7 @@ class TestJollyJack(unittest.TestCase):
                                     , use_memory_map = use_memory_map
                                     , row_ranges = [slice(chunk_size, chunk_size - 1)])
             self.assertTrue(f"Row range 'slice({chunk_size}, {chunk_size - 1}, None)' is not a valid range" in str(context.exception), context.exception)
-
+            
             with self.assertRaises(RuntimeError) as context:
                 jj.read_into_numpy (source = path
                                     , metadata = None
@@ -930,19 +930,19 @@ class TestJollyJack(unittest.TestCase):
 
             pr.close()
 
-    @parameterized.expand(itertools.product([pa.float16(), pa.float32(), pa.float64()],
-                                            [(1, 1), (5,6),(8, 8), (16, 16),
-                                             (32, 32), (32, 33), (33, 32), (64, 64),
+    @parameterized.expand(itertools.product([pa.float16(), pa.float32(), pa.float64()], 
+                                            [(1, 1), (5,6),(8, 8), (16, 16), 
+                                             (32, 32), (32, 33), (33, 32), (64, 64), 
                                              (65, 64), (64, 65), (100, 200), (1000, 2000)]))
     def test_copy_to_numpy_row_major(self, dtype, n_rows_n_columns):
 
         n_rows = n_rows_n_columns[0]
         n_columns = n_rows_n_columns[1]
-
+        
         src_array = get_table(n_rows, n_columns, data_type = dtype).to_pandas().to_numpy()
         dst_array = np.zeros((n_rows, n_columns), dtype=dtype.to_pandas_dtype(), order='C')
         expected_array = np.zeros((n_rows, n_columns), dtype=dtype.to_pandas_dtype(), order='C')
-        np.copyto(expected_array, src_array)
+        np.copyto(expected_array, src_array)                   
         jj.copy_to_numpy_row_major(src_array = src_array, dst_array = dst_array, row_indices = range(n_rows))
         self.assertTrue(np.array_equal(expected_array, dst_array), f"{expected_array}\n!=\n{dst_array}")
 
@@ -952,12 +952,12 @@ class TestJollyJack(unittest.TestCase):
         self.assertTrue(np.array_equal(expected_array, dst_array), f"{expected_array}\n!=\n{dst_array}")
 
         # Subsets
-        src_view = src_array[1:(n_rows - 1), 1:(n_columns - 1)]
+        src_view = src_array[1:(n_rows - 1), 1:(n_columns - 1)] 
         dst_array = np.zeros((n_rows, n_columns), dtype=dtype.to_pandas_dtype(), order='C')
-        dst_view = dst_array[1:(n_rows - 1), 1:(n_columns - 1)]
+        dst_view = dst_array[1:(n_rows - 1), 1:(n_columns - 1)] 
         expected_array = np.zeros((n_rows, n_columns), dtype=dtype.to_pandas_dtype(), order='C')
         np.copyto(expected_array, src_array)
-        expected_array = expected_array[1:(n_rows - 1), 1:(n_columns - 1)]
+        expected_array = expected_array[1:(n_rows - 1), 1:(n_columns - 1)]    
         jj.copy_to_numpy_row_major(src_array = src_view, dst_array = dst_view, row_indices = range(n_rows - 2))
         self.assertTrue(np.array_equal(expected_array, dst_view), f"{expected_array}\n!=\n{dst_view}")
 
@@ -973,7 +973,7 @@ class TestJollyJack(unittest.TestCase):
 
         src_tensor = torch.tensor(get_table(n_rows, n_columns, data_type = dtype).to_pandas().to_numpy())
         dst_tensor = torch.zeros(n_rows, n_columns, dtype = numpy_to_torch_dtype_dict[dtype.to_pandas_dtype()])
-        expected_tensor = src_tensor.clone().contiguous()
+        expected_tensor = src_tensor.clone().contiguous()   
         jj.copy_to_torch_row_major(src_tensor = src_tensor, dst_tensor = dst_tensor, row_indices = range(n_rows))
         self.assertTrue(torch.equal(expected_tensor, dst_tensor), f"{expected_tensor}\n!=\n{dst_tensor}")
 


### PR DESCRIPTION
I have a case where it would be convenient to read integer columns from a Parquet file with JollyJack. This PR adds `INT{32,64}` branches to `ReadColumn` that are direct adaptations of the `{FLOAT,DOUBLE}` branches.